### PR TITLE
Fix collaborator repository query parameter type

### DIFF
--- a/backend/com.tessera/src/main/java/com/tessera/backend/repository/DocumentCollaboratorRepository.java
+++ b/backend/com.tessera/src/main/java/com/tessera/backend/repository/DocumentCollaboratorRepository.java
@@ -48,8 +48,8 @@ public interface DocumentCollaboratorRepository extends JpaRepository<DocumentCo
     @Query("SELECT c FROM DocumentCollaborator c " +
            "WHERE c.document = :document AND c.active = true " +
            "AND c.permission = :permission")
-    List<DocumentCollaborator> findByDocumentAndPermissionAndActiveTrue(@Param("document") Document document, 
-                                                                       @Param("permission") String permission);
+    List<DocumentCollaborator> findByDocumentAndPermissionAndActiveTrue(@Param("document") Document document,
+                                                                       @Param("permission") CollaboratorPermission permission);
     
     // Histórico de colaboradores (incluindo inativos)
     List<DocumentCollaborator> findByDocumentOrderByAddedAtDesc(Document document);

--- a/srcs/src/main/java/com/tessera/backend/repository/DocumentCollaboratorRepository.java
+++ b/srcs/src/main/java/com/tessera/backend/repository/DocumentCollaboratorRepository.java
@@ -48,8 +48,8 @@ public interface DocumentCollaboratorRepository extends JpaRepository<DocumentCo
     @Query("SELECT c FROM DocumentCollaborator c " +
            "WHERE c.document = :document AND c.active = true " +
            "AND c.permission = :permission")
-    List<DocumentCollaborator> findByDocumentAndPermissionAndActiveTrue(@Param("document") Document document, 
-                                                                       @Param("permission") String permission);
+    List<DocumentCollaborator> findByDocumentAndPermissionAndActiveTrue(@Param("document") Document document,
+                                                                       @Param("permission") CollaboratorPermission permission);
     
     // Histórico de colaboradores (incluindo inativos)
     List<DocumentCollaborator> findByDocumentOrderByAddedAtDesc(Document document);


### PR DESCRIPTION
## Summary
- fix query param type for `findByDocumentAndPermissionAndActiveTrue`

## Testing
- `./mvnw -q -DskipTests package` *(fails: Failed to fetch)*
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_683f509defa88327987f315accf2edf2