### PR TITLE
Fix permission calculations for collaborator DTO

### DIFF
--- a/backend/com.tessera/src/main/java/com/tessera/backend/service/DocumentCollaboratorService.java
+++ b/backend/com.tessera/src/main/java/com/tessera/backend/service/DocumentCollaboratorService.java
@@ -343,6 +343,7 @@ public class DocumentCollaboratorService {
         dto.setUserEmail(collaborator.getUser().getEmail());
         dto.setRole(collaborator.getRole());
         dto.setPermission(collaborator.getPermission());
+        dto.recalculatePermissions();
         dto.setAddedAt(collaborator.getAddedAt());
         dto.setAddedByName(collaborator.getAddedBy() != null ? collaborator.getAddedBy().getName() : null);
         dto.setActive(collaborator.isActive());


### PR DESCRIPTION
## Summary
- trigger recalculation of permissions when mapping `DocumentCollaborator` to its DTO

## Testing
- `./mvnw -q test` *(fails: Non-resolvable parent POM due to network unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_683f64598f308327a8d8232521651715