### PR TITLE
Add global ErrorBoundary

### DIFF
--- a/frontend/src/components/ErrorBoundary.tsx
+++ b/frontend/src/components/ErrorBoundary.tsx
@@ -1,0 +1,33 @@
+// src/components/ErrorBoundary.tsx
+import React from 'react';
+import { ErrorBoundary as ReactErrorBoundary, FallbackProps } from 'react-error-boundary';
+
+const ErrorFallback: React.FC<FallbackProps> = ({ error, resetErrorBoundary }) => {
+  // Log the error to an external service or console
+  console.error('Uncaught error:', error);
+
+  return (
+    <div role="alert" className="p-8 text-center">
+      <h2 className="text-2xl font-semibold mb-4 text-red-600">Algo deu errado</h2>
+      <p className="mb-6 text-gray-700">Ocorreu um erro inesperado. Tente novamente.</p>
+      <button
+        onClick={resetErrorBoundary}
+        className="px-4 py-2 bg-primary-600 text-white rounded hover:bg-primary-700"
+      >
+        Recarregar página
+      </button>
+    </div>
+  );
+};
+
+interface BoundaryProps {
+  children: React.ReactNode;
+}
+
+export const ErrorBoundary: React.FC<BoundaryProps> = ({ children }) => (
+  <ReactErrorBoundary FallbackComponent={ErrorFallback}>
+    {children}
+  </ReactErrorBoundary>
+);
+
+export default ErrorBoundary;

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -2,9 +2,12 @@ import { StrictMode } from 'react'
 import { createRoot } from 'react-dom/client'
 import './index.css'
 import App from './App.tsx'
+import ErrorBoundary from './components/ErrorBoundary'
 
 createRoot(document.getElementById('root')!).render(
   <StrictMode>
-    <App />
+    <ErrorBoundary>
+      <App />
+    </ErrorBoundary>
   </StrictMode>,
 )


### PR DESCRIPTION
## Summary
- add an ErrorBoundary component using `react-error-boundary`
- wrap `<App />` with the boundary in `main.tsx`

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_683f6a82680c8327b7a65573006bcc27