### PR TITLE
Fix toast info call

### DIFF
--- a/frontend/src/pages/DocumentEditPage.tsx
+++ b/frontend/src/pages/DocumentEditPage.tsx
@@ -394,7 +394,9 @@ const DocumentEditPage: React.FC = () => {
         if (infoUpdated || versionCreated) {
             toast.success('Documento atualizado com sucesso!');
         } else {
-            toast.info('Nenhuma alteração detectada para salvar.');
+            // react-hot-toast doesn't provide a dedicated `info` helper.
+            // Use the default toast function to display informational messages.
+            toast('Nenhuma alteração detectada para salvar.');
         }
 
       } else {


### PR DESCRIPTION
## Summary
- remove invalid `toast.info` usage in DocumentEditPage

## Testing
- `./mvnw test -q` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_683f76bc2b648327bca5fa61ff93275c