### PR TITLE
Remove StrictMode from React root

### DIFF
--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -1,13 +1,10 @@
-import { StrictMode } from 'react'
 import { createRoot } from 'react-dom/client'
 import './index.css'
 import App from './App.tsx'
 import ErrorBoundary from './components/ErrorBoundary'
 
 createRoot(document.getElementById('root')!).render(
-  <StrictMode>
-    <ErrorBoundary>
-      <App />
-    </ErrorBoundary>
-  </StrictMode>,
+  <ErrorBoundary>
+    <App />
+  </ErrorBoundary>,
 )


### PR DESCRIPTION
## Summary
- remove `<StrictMode>` from the React entrypoint so `ErrorBoundary` is the outermost component

## Testing
- `npm run lint` *(fails: Invalid option '--ext')*
- `npm run build`
- `./mvnw test` *(fails: could not download dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_683f7f04ed908327913b21b6eae5effe