### PR TITLE
Implement settings modal placeholder

### DIFF
--- a/frontend/src/components/Layout/Header.tsx
+++ b/frontend/src/components/Layout/Header.tsx
@@ -16,9 +16,10 @@ import { toast } from 'react-hot-toast';
 interface HeaderProps {
   onMenuClick: () => void;
   onNotificationBellClick: () => void; // Nova prop para lidar com o clique no sino
+  onSettingsClick: () => void;
 }
 
-const Header: React.FC<HeaderProps> = ({ onMenuClick, onNotificationBellClick }) => {
+const Header: React.FC<HeaderProps> = ({ onMenuClick, onNotificationBellClick, onSettingsClick }) => {
   const { user, clearAuth } = useAuthStore();
   const { summary: notificationSummary } = useNotificationSummaryStore(); // Obter o resumo da store
   const [userMenuOpen, setUserMenuOpen] = useState(false);
@@ -156,8 +157,7 @@ const Header: React.FC<HeaderProps> = ({ onMenuClick, onNotificationBellClick })
                     <button
                       onClick={() => {
                         setUserMenuOpen(false);
-                        toast.error('Modal de configurações ainda não implementado.');
-                        // TODO: Abrir modal de configurações
+                        onSettingsClick();
                       }}
                       className="flex items-center w-full px-4 py-2 text-sm text-gray-700 hover:bg-gray-100"
                     >

--- a/frontend/src/components/Layout/Layout.tsx
+++ b/frontend/src/components/Layout/Layout.tsx
@@ -4,14 +4,20 @@ import { Outlet } from 'react-router-dom';
 import Sidebar from './Sidebar';
 import Header from './Header';
 import NotificationCenter from '../Notifications/NotificationCenter'; // Importar o NotificationCenter
+import SettingsModal from './SettingsModal';
 import { WebSocketProvider } from '../providers/WebSocketProvider'; // Importar o WebSocketProvider
 
 const Layout: React.FC = () => {
   const [sidebarOpen, setSidebarOpen] = useState(false);
   const [isNotificationCenterOpen, setIsNotificationCenterOpen] = useState(false); // Estado para a Central de Notificações
+  const [isSettingsModalOpen, setIsSettingsModalOpen] = useState(false);
 
   const toggleNotificationCenter = () => {
     setIsNotificationCenterOpen(!isNotificationCenterOpen);
+  };
+
+  const openSettingsModal = () => {
+    setIsSettingsModalOpen(true);
   };
 
   return (
@@ -23,9 +29,10 @@ const Layout: React.FC = () => {
         {/* Main content */}
         <div className="flex-1 flex flex-col overflow-hidden">
           {/* Header */}
-          <Header 
-            onMenuClick={() => setSidebarOpen(true)} 
+          <Header
+            onMenuClick={() => setSidebarOpen(true)}
             onNotificationBellClick={toggleNotificationCenter} // Passar a função para o Header
+            onSettingsClick={openSettingsModal}
           />
 
           {/* Main content area */}
@@ -37,9 +44,13 @@ const Layout: React.FC = () => {
         </div>
 
         {/* Notification Center */}
-        <NotificationCenter 
-          isOpen={isNotificationCenterOpen} 
-          onClose={() => setIsNotificationCenterOpen(false)} 
+        <NotificationCenter
+          isOpen={isNotificationCenterOpen}
+          onClose={() => setIsNotificationCenterOpen(false)}
+        />
+        <SettingsModal
+          isOpen={isSettingsModalOpen}
+          onClose={() => setIsSettingsModalOpen(false)}
         />
       </div>
     </WebSocketProvider>

--- a/frontend/src/components/Layout/SettingsModal.tsx
+++ b/frontend/src/components/Layout/SettingsModal.tsx
@@ -1,0 +1,44 @@
+import React from 'react';
+import { XMarkIcon, Cog6ToothIcon } from '@heroicons/react/24/outline';
+
+interface SettingsModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+}
+
+const SettingsModal: React.FC<SettingsModalProps> = ({ isOpen, onClose }) => {
+  if (!isOpen) return null;
+
+  return (
+    <div className="fixed inset-0 bg-gray-600 bg-opacity-75 overflow-y-auto h-full w-full z-50 flex items-center justify-center p-4">
+      <div className="relative bg-white rounded-lg shadow-xl w-full max-w-lg">
+        <div className="flex items-start justify-between p-5 border-b rounded-t">
+          <h3 className="text-xl font-semibold text-gray-900 flex items-center">
+            <Cog6ToothIcon className="h-6 w-6 mr-2 text-primary-600" />
+            Configurações
+          </h3>
+          <button
+            type="button"
+            className="text-gray-400 bg-transparent hover:bg-gray-200 hover:text-gray-900 rounded-lg text-sm p-1.5 ml-auto inline-flex items-center"
+            onClick={onClose}
+          >
+            <XMarkIcon className="w-5 h-5" />
+            <span className="sr-only">Fechar modal</span>
+          </button>
+        </div>
+        <div className="p-6 space-y-4">
+          <p className="text-sm text-gray-600">
+            Em breve você poderá personalizar diversas opções de configuração.
+          </p>
+        </div>
+        <div className="flex items-center justify-end p-6 space-x-2 border-t border-gray-200 rounded-b">
+          <button type="button" className="btn btn-primary" onClick={onClose}>
+            Fechar
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default SettingsModal;


### PR DESCRIPTION
## Summary
- add SettingsModal component with placeholder content
- open SettingsModal from Header
- wire SettingsModal through Layout

## Testing
- `npm run lint` *(fails: Invalid option '--ext')*
- `npm run build`
- `./mvnw -q test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_683f7f09435483279e27ce7cae87d6d3