### PR TITLE
Implement generic document listing API

### DIFF
--- a/backend/com.tessera/src/main/java/com/tessera/backend/controller/DocumentController.java
+++ b/backend/com.tessera/src/main/java/com/tessera/backend/controller/DocumentController.java
@@ -52,12 +52,24 @@ public class DocumentController {
         @ApiResponse(responseCode = "404", description = "Estudante ou orientador não encontrado")
     })
     public ResponseEntity<DocumentDTO> createDocument(
-            @Parameter(description = "Dados do documento a ser criado") 
+            @Parameter(description = "Dados do documento a ser criado")
             @Valid @RequestBody DocumentDTO documentDTO,
             Authentication authentication) {
         User currentUser = getCurrentUser(authentication);
         DocumentDTO createdDocument = documentService.createDocument(documentDTO, currentUser);
         return new ResponseEntity<>(createdDocument, HttpStatus.CREATED);
+    }
+
+    @GetMapping
+    @PreAuthorize("isAuthenticated()")
+    @Operation(summary = "Listar documentos",
+               description = "Retorna uma lista paginada de documentos com filtros de busca e status."
+    )
+    public ResponseEntity<Page<DocumentDTO>> getAllDocuments(
+            @RequestParam(required = false) String searchTerm,
+            @RequestParam(required = false, defaultValue = "ALL") String status,
+            @PageableDefault(sort = "updatedAt", direction = Sort.Direction.DESC) Pageable pageable) {
+        return ResponseEntity.ok(documentService.getAllDocuments(searchTerm, status, pageable));
     }
     
     @GetMapping("/{id}")

--- a/backend/com.tessera/src/main/java/com/tessera/backend/repository/DocumentRepository.java
+++ b/backend/com.tessera/src/main/java/com/tessera/backend/repository/DocumentRepository.java
@@ -60,9 +60,25 @@ public interface DocumentRepository extends JpaRepository<Document, Long> {
            "JOIN d.collaborators c " +
            "WHERE c.user = :user AND c.active = true")
     long countByCollaborator(@Param("user") User user);
-    
+
     @Query("SELECT COUNT(DISTINCT d) FROM Document d " +
            "JOIN d.collaborators c " +
            "WHERE c.user = :user AND c.active = true AND d.status = :status")
     long countByCollaboratorAndStatus(@Param("user") User user, @Param("status") DocumentStatus status);
+
+    // ----------------------------------------------------------------------
+    // Consultas para listagem geral de documentos (para admins ou páginas de
+    // listagem genérica) com filtros de busca e status
+    // ----------------------------------------------------------------------
+
+    @Query("SELECT d FROM Document d WHERE (:status IS NULL OR d.status = :status)")
+    Page<Document> findAllByStatus(@Param("status") DocumentStatus status, Pageable pageable);
+
+    @Query("SELECT d FROM Document d " +
+           "WHERE (:status IS NULL OR d.status = :status) " +
+           "AND ( :searchTerm IS NULL OR LOWER(d.title) LIKE LOWER(CONCAT('%', :searchTerm, '%')) " +
+           "      OR LOWER(d.description) LIKE LOWER(CONCAT('%', :searchTerm, '%')) )")
+    Page<Document> findAllWithFilters(@Param("searchTerm") String searchTerm,
+                                      @Param("status") DocumentStatus status,
+                                      Pageable pageable);
 }

--- a/backend/com.tessera/src/main/java/com/tessera/backend/service/DocumentService.java
+++ b/backend/com.tessera/src/main/java/com/tessera/backend/service/DocumentService.java
@@ -165,6 +165,24 @@ public class DocumentService {
         return documentsPage.map(this::mapToDTO);
     }
 
+    @Transactional(readOnly = true)
+    public Page<DocumentDTO> getAllDocuments(String searchTerm, String statusFilter, Pageable pageable) {
+        logger.debug("Listando todos os documentos, searchTerm: '{}', statusFilter: '{}', pageable: {}", searchTerm, statusFilter, pageable);
+        DocumentStatus status = parseStatus(statusFilter);
+        String trimmedSearchTerm = StringUtils.hasText(searchTerm) ? searchTerm.trim().toLowerCase() : null;
+
+        Page<Document> documentsPage;
+        if (trimmedSearchTerm != null) {
+            documentsPage = documentRepository.findAllWithFilters(trimmedSearchTerm, status, pageable);
+        } else if (status != null) {
+            documentsPage = documentRepository.findAllByStatus(status, pageable);
+        } else {
+            documentsPage = documentRepository.findAll(pageable);
+        }
+        logger.info("Encontrados {} documentos na página {}", documentsPage.getNumberOfElements(), pageable.getPageNumber());
+        return documentsPage.map(this::mapToDTO);
+    }
+
     @Transactional
     public DocumentDTO updateDocument(Long id, DocumentDTO documentDTO, final User currentUser) {
         logger.info("Tentativa de atualização do documento ID {} por {}", id, currentUser.getEmail());


### PR DESCRIPTION
## Summary
- enable listing documents via `GET /documents`
- support search and status filters in DocumentService and repository

## Testing
- `./mvnw -q test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_683f82a342c883279e6c89a100b0403e