### PR TITLE
Fix duplicate collaborator insertion

### DIFF
--- a/backend/com.tessera/src/main/java/com/tessera/backend/repository/DocumentCollaboratorRepository.java
+++ b/backend/com.tessera/src/main/java/com/tessera/backend/repository/DocumentCollaboratorRepository.java
@@ -22,6 +22,7 @@ public interface DocumentCollaboratorRepository extends JpaRepository<DocumentCo
     List<DocumentCollaborator> findByDocumentAndActiveTrue(Document document);
     List<DocumentCollaborator> findByUserAndActiveTrue(User user);
     Optional<DocumentCollaborator> findByDocumentAndUserAndActiveTrue(Document document, User user);
+    Optional<DocumentCollaborator> findByDocumentAndUser(Document document, User user);
     
     // Buscar por papel específico
     List<DocumentCollaborator> findByDocumentAndRoleAndActiveTrue(Document document, CollaboratorRole role);


### PR DESCRIPTION
## Summary
- allow retrieving collaborators regardless of their active state
- reactivate existing collaborators instead of failing with unique constraint violation
- cover collaborator reactivation with a new unit test

## Testing
- `./mvnw -q test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_683f84ed156c832783841958cd34e780