### PR TITLE
Add unit tests for document and version services

### DIFF
--- a/backend/com.tessera/src/test/java/com/tessera/backend/service/DocumentServiceTest.java
+++ b/backend/com.tessera/src/test/java/com/tessera/backend/service/DocumentServiceTest.java
@@ -1,0 +1,179 @@
+package com.tessera.backend.service;
+
+import com.tessera.backend.dto.DocumentDTO;
+import com.tessera.backend.entity.*;
+import com.tessera.backend.exception.UnauthorizedOperationException;
+import com.tessera.backend.repository.DocumentCollaboratorRepository;
+import com.tessera.backend.repository.DocumentRepository;
+import com.tessera.backend.repository.UserRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.LocalDateTime;
+import java.util.*;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class DocumentServiceTest {
+
+    @InjectMocks
+    private DocumentService service;
+
+    @Mock
+    private DocumentRepository documentRepository;
+    @Mock
+    private UserRepository userRepository;
+    @Mock
+    private DocumentCollaboratorRepository collaboratorRepository;
+    @Mock
+    private NotificationEventService notificationEventService;
+
+    private User student;
+    private User advisor;
+
+    @BeforeEach
+    void setup() {
+        student = createUser(1L, "Student", "student@test.com", "STUDENT");
+        advisor = createUser(2L, "Advisor", "advisor@test.com", "ADVISOR");
+    }
+
+    private User createUser(Long id, String name, String email, String roleName) {
+        User u = new User();
+        u.setId(id);
+        u.setName(name);
+        u.setEmail(email);
+        u.setPassword("pwd");
+        Role role = new Role(roleName);
+        u.setRoles(new HashSet<>(Set.of(role)));
+        return u;
+    }
+
+    private Document createDraftDocument() {
+        Document doc = new Document();
+        doc.setId(10L);
+        doc.setStatus(DocumentStatus.DRAFT);
+        doc.setStudent(student);
+        doc.setAdvisor(advisor);
+
+        DocumentCollaborator collab = new DocumentCollaborator();
+        collab.setDocument(doc);
+        collab.setUser(student);
+        collab.setRole(CollaboratorRole.PRIMARY_STUDENT);
+        collab.setPermission(CollaboratorPermission.FULL_ACCESS);
+        collab.setActive(true);
+        doc.setCollaborators(new ArrayList<>(List.of(collab)));
+        return doc;
+    }
+
+    @Test
+    void testCreateDocumentSuccess() {
+        DocumentDTO dto = new DocumentDTO();
+        dto.setTitle("My Doc");
+        dto.setDescription("Desc");
+        dto.setStudentId(student.getId());
+        dto.setAdvisorId(advisor.getId());
+
+        when(userRepository.findById(student.getId())).thenReturn(Optional.of(student));
+        when(userRepository.findById(advisor.getId())).thenReturn(Optional.of(advisor));
+        when(documentRepository.save(any())).thenAnswer(inv -> {
+            Document d = inv.getArgument(0);
+            d.setId(5L);
+            return d;
+        });
+        when(collaboratorRepository.save(any())).thenAnswer(inv -> inv.getArgument(0));
+
+        DocumentDTO result = service.createDocument(dto, student);
+
+        assertEquals(5L, result.getId());
+        verify(collaboratorRepository, times(2)).save(any(DocumentCollaborator.class));
+        verify(notificationEventService).onDocumentCreated(any(Document.class), eq(student));
+    }
+
+    @Test
+    void testCreateDocumentUnauthorized() {
+        DocumentDTO dto = new DocumentDTO();
+        dto.setTitle("My Doc");
+        dto.setDescription("Desc");
+        dto.setStudentId(student.getId());
+        dto.setAdvisorId(advisor.getId());
+        User other = createUser(3L, "Other", "o@test.com", "ADVISOR");
+
+        when(userRepository.findById(student.getId())).thenReturn(Optional.of(student));
+        when(userRepository.findById(advisor.getId())).thenReturn(Optional.of(advisor));
+
+        assertThrows(UnauthorizedOperationException.class, () -> service.createDocument(dto, other));
+        verify(documentRepository, never()).save(any());
+    }
+
+    @Test
+    void testChangeStatusSubmitSuccess() {
+        Document document = createDraftDocument();
+        when(documentRepository.findById(document.getId())).thenReturn(Optional.of(document));
+        when(documentRepository.save(any())).thenAnswer(inv -> inv.getArgument(0));
+
+        DocumentDTO dto = service.changeStatus(document.getId(), DocumentStatus.SUBMITTED, student, null);
+
+        assertEquals(DocumentStatus.SUBMITTED, dto.getStatus());
+        assertNotNull(document.getSubmittedAt());
+        verify(notificationEventService).onDocumentStatusChanged(document, DocumentStatus.DRAFT, student);
+        verify(documentRepository).save(document);
+    }
+
+    @Test
+    void testChangeStatusUnauthorized() {
+        Document document = createDraftDocument();
+        when(documentRepository.findById(document.getId())).thenReturn(Optional.of(document));
+
+        User stranger = createUser(4L, "Stranger", "s@test.com", "ADVISOR");
+        assertThrows(UnauthorizedOperationException.class,
+                () -> service.changeStatus(document.getId(), DocumentStatus.SUBMITTED, stranger, null));
+        verify(documentRepository, never()).save(any());
+    }
+
+    @Test
+    void testChangeStatusInvalidTransition() {
+        Document document = createDraftDocument();
+        document.setStatus(DocumentStatus.APPROVED);
+        when(documentRepository.findById(document.getId())).thenReturn(Optional.of(document));
+
+        assertThrows(IllegalStateException.class,
+                () -> service.changeStatus(document.getId(), DocumentStatus.SUBMITTED, student, null));
+        verify(documentRepository, never()).save(any());
+    }
+
+    @Test
+    void testUpdateDocumentChangeAdvisor() {
+        Document document = createDraftDocument();
+        DocumentCollaborator primaryAdvisorCollab = new DocumentCollaborator();
+        primaryAdvisorCollab.setDocument(document);
+        primaryAdvisorCollab.setUser(advisor);
+        primaryAdvisorCollab.setRole(CollaboratorRole.PRIMARY_ADVISOR);
+        primaryAdvisorCollab.setPermission(CollaboratorPermission.FULL_ACCESS);
+        primaryAdvisorCollab.setActive(true);
+        document.getCollaborators().add(primaryAdvisorCollab);
+
+        User newAdvisor = createUser(5L, "NewAdv", "n@test.com", "ADVISOR");
+        DocumentDTO dto = new DocumentDTO();
+        dto.setAdvisorId(newAdvisor.getId());
+
+        when(documentRepository.findById(document.getId())).thenReturn(Optional.of(document));
+        when(userRepository.findById(newAdvisor.getId())).thenReturn(Optional.of(newAdvisor));
+        when(collaboratorRepository.save(any())).thenAnswer(inv -> inv.getArgument(0));
+        when(documentRepository.save(any())).thenAnswer(inv -> inv.getArgument(0));
+
+        DocumentDTO result = service.updateDocument(document.getId(), dto, student);
+
+        assertEquals(newAdvisor.getId(), document.getAdvisor().getId());
+        assertEquals(CollaboratorRole.SECONDARY_ADVISOR, primaryAdvisorCollab.getRole());
+        verify(collaboratorRepository, times(2)).save(any(DocumentCollaborator.class));
+        assertEquals(newAdvisor.getId(), result.getAdvisorId());
+    }
+}

--- a/backend/com.tessera/src/test/java/com/tessera/backend/service/VersionServiceTest.java
+++ b/backend/com.tessera/src/test/java/com/tessera/backend/service/VersionServiceTest.java
@@ -1,0 +1,134 @@
+package com.tessera.backend.service;
+
+import com.tessera.backend.dto.VersionDTO;
+import com.tessera.backend.entity.*;
+import com.tessera.backend.repository.DocumentRepository;
+import com.tessera.backend.repository.VersionRepository;
+import com.tessera.backend.util.DiffUtils;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.*;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class VersionServiceTest {
+
+    @InjectMocks
+    private VersionService service;
+
+    @Mock
+    private VersionRepository versionRepository;
+    @Mock
+    private DocumentRepository documentRepository;
+    @Mock
+    private DiffUtils diffUtils;
+    @Mock
+    private NotificationEventService notificationEventService;
+
+    private User student;
+    private Document document;
+
+    @BeforeEach
+    void setup() {
+        student = createUser(1L, "Student", "s@test.com", "STUDENT");
+        document = new Document();
+        document.setId(100L);
+        document.setStatus(DocumentStatus.DRAFT);
+        document.setStudent(student);
+    }
+
+    private User createUser(Long id, String name, String email, String roleName) {
+        User u = new User();
+        u.setId(id);
+        u.setName(name);
+        u.setEmail(email);
+        Role r = new Role(roleName);
+        u.setRoles(new HashSet<>(Set.of(r)));
+        return u;
+    }
+
+    @Test
+    void testCreateVersionSuccess() {
+        VersionDTO dto = new VersionDTO();
+        dto.setDocumentId(document.getId());
+        dto.setContent("data");
+        dto.setCommitMessage("msg");
+
+        when(documentRepository.findById(document.getId())).thenReturn(Optional.of(document));
+        when(versionRepository.findByDocumentOrderByCreatedAtDesc(document)).thenReturn(Collections.emptyList());
+        when(versionRepository.findLatestByDocument(document)).thenReturn(Optional.empty());
+        when(versionRepository.save(any())).thenAnswer(inv -> {
+            Version v = inv.getArgument(0);
+            v.setId(5L);
+            return v;
+        });
+
+        VersionDTO result = service.createVersion(dto, student);
+
+        assertEquals("1.0", result.getVersionNumber());
+        verify(versionRepository).save(any(Version.class));
+        verify(notificationEventService).onVersionCreated(any(Version.class), eq(student));
+        verify(documentRepository, never()).save(any());
+    }
+
+    @Test
+    void testCreateVersionUnauthorized() {
+        User other = createUser(2L, "Other", "o@test.com", "STUDENT");
+        VersionDTO dto = new VersionDTO();
+        dto.setDocumentId(document.getId());
+        dto.setContent("c");
+
+        when(documentRepository.findById(document.getId())).thenReturn(Optional.of(document));
+
+        assertThrows(RuntimeException.class, () -> service.createVersion(dto, other));
+        verify(versionRepository, never()).save(any());
+    }
+
+    @Test
+    void testCreateVersionInvalidStatus() {
+        document.setStatus(DocumentStatus.APPROVED);
+        VersionDTO dto = new VersionDTO();
+        dto.setDocumentId(document.getId());
+        dto.setContent("c");
+
+        when(documentRepository.findById(document.getId())).thenReturn(Optional.of(document));
+
+        assertThrows(RuntimeException.class, () -> service.createVersion(dto, student));
+        verify(versionRepository, never()).save(any());
+    }
+
+    @Test
+    void testCreateVersionFromRevision() {
+        document.setStatus(DocumentStatus.REVISION);
+        Version prev = new Version();
+        prev.setVersionNumber("1.0");
+        prev.setContent("old");
+
+        VersionDTO dto = new VersionDTO();
+        dto.setDocumentId(document.getId());
+        dto.setContent("new");
+        dto.setCommitMessage("msg");
+
+        when(documentRepository.findById(document.getId())).thenReturn(Optional.of(document));
+        when(versionRepository.findByDocumentOrderByCreatedAtDesc(document)).thenReturn(List.of(prev));
+        when(versionRepository.findLatestByDocument(document)).thenReturn(Optional.of(prev));
+        when(diffUtils.generateDiff("old", "new")).thenReturn("diff");
+        when(versionRepository.save(any())).thenAnswer(inv -> inv.getArgument(0));
+        when(documentRepository.save(document)).thenReturn(document);
+
+        VersionDTO result = service.createVersion(dto, student);
+
+        assertEquals("1.1", result.getVersionNumber());
+        assertEquals("diff", result.getDiffFromPrevious());
+        assertEquals(DocumentStatus.SUBMITTED, document.getStatus());
+        verify(documentRepository).save(document);
+    }
+}


### PR DESCRIPTION
## Summary
- create `DocumentServiceTest` covering permission checks, status transitions, and collaborator updates
- create `VersionServiceTest` mocking version creation logic

## Testing
- `./backend/com.tessera/mvnw -q -f backend/com.tessera/pom.xml test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_683f9035c7988327843355ce04b63e55