### PR TITLE
Fix collaborator persistence on document creation

### DIFF
--- a/backend/com.tessera/src/main/java/com/tessera/backend/service/DocumentService.java
+++ b/backend/com.tessera/src/main/java/com/tessera/backend/service/DocumentService.java
@@ -117,11 +117,12 @@ public class DocumentService {
         collaboratorRepository.save(advisorCollaborator);
         logger.info("Colaborador Orientador Principal (ID: {}) adicionado ao Documento ID: {}", advisorUser.getId(), document.getId());
 
-        // Adicionar à lista de colaboradores do documento se a gestão for feita pela entidade Document
-        // document.getCollaborators().add(studentCollaborator);
-        // document.getCollaborators().add(advisorCollaborator);
-        // Se o DocumentRepository salva o Document e os Collaborators são salvos separadamente,
-        // o importante é que as referências estejam corretas.
+        // Adicionar à lista de colaboradores do documento para manter a relação bi-direcional
+        document.getCollaborators().add(studentCollaborator);
+        document.getCollaborators().add(advisorCollaborator);
+
+        // Persistir o documento atualizado para garantir que o relacionamento seja salvo
+        documentRepository.save(document);
     }
 
     @Transactional(readOnly = true) // Adicionar aqui também para consistência e garantir que o mapeamento está na transação

--- a/backend/com.tessera/src/test/java/com/tessera/backend/service/DocumentServiceTest.java
+++ b/backend/com.tessera/src/test/java/com/tessera/backend/service/DocumentServiceTest.java
@@ -1,0 +1,81 @@
+package com.tessera.backend.service;
+
+import com.tessera.backend.dto.DocumentDTO;
+import com.tessera.backend.entity.*;
+import com.tessera.backend.repository.DocumentCollaboratorRepository;
+import com.tessera.backend.repository.DocumentRepository;
+import com.tessera.backend.repository.UserRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.*;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class DocumentServiceTest {
+
+    @InjectMocks
+    private DocumentService service;
+
+    @Mock
+    private DocumentRepository documentRepository;
+    @Mock
+    private UserRepository userRepository;
+    @Mock
+    private DocumentCollaboratorRepository collaboratorRepository;
+    @Mock
+    private NotificationEventService notificationEventService;
+
+    private User student;
+    private User advisor;
+
+    @BeforeEach
+    void setup() {
+        student = createUser(1L, "Student", "student@test.com", "STUDENT");
+        advisor = createUser(2L, "Advisor", "advisor@test.com", "ADVISOR");
+    }
+
+    private User createUser(Long id, String name, String email, String roleName) {
+        User u = new User();
+        u.setId(id);
+        u.setName(name);
+        u.setEmail(email);
+        Role role = new Role(roleName);
+        u.setRoles(new HashSet<>(Set.of(role)));
+        return u;
+    }
+
+    @Test
+    void testCreateDocumentAddsPrimaryCollaboratorsToDocument() {
+        DocumentDTO dto = new DocumentDTO();
+        dto.setTitle("Doc");
+        dto.setDescription("desc");
+        dto.setStudentId(student.getId());
+        dto.setAdvisorId(advisor.getId());
+
+        when(userRepository.findById(student.getId())).thenReturn(Optional.of(student));
+        when(userRepository.findById(advisor.getId())).thenReturn(Optional.of(advisor));
+        when(collaboratorRepository.save(any())).thenAnswer(inv -> inv.getArgument(0));
+        when(documentRepository.save(any(Document.class))).thenAnswer(inv -> inv.getArgument(0));
+
+        ArgumentCaptor<Document> captor = ArgumentCaptor.forClass(Document.class);
+
+        service.createDocument(dto, student);
+
+        verify(documentRepository, times(2)).save(captor.capture());
+        Document finalDoc = captor.getAllValues().get(1);
+        assertEquals(2, finalDoc.getCollaborators().size());
+        assertTrue(finalDoc.getCollaborators().stream()
+                .anyMatch(c -> c.getUser() == student && c.getRole() == CollaboratorRole.PRIMARY_STUDENT));
+        assertTrue(finalDoc.getCollaborators().stream()
+                .anyMatch(c -> c.getUser() == advisor && c.getRole() == CollaboratorRole.PRIMARY_ADVISOR));
+    }
+}


### PR DESCRIPTION
## Summary
- ensure primary collaborators are added to the document list and persisted
- test creation of document adds primary collaborators

## Testing
- `./mvnw -q test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_683f90357d788327be34a2f91d6f68ae