### PR TITLE
Enable collaborators to create versions

### DIFF
--- a/backend/com.tessera/src/main/java/com/tessera/backend/service/VersionService.java
+++ b/backend/com.tessera/src/main/java/com/tessera/backend/service/VersionService.java
@@ -38,9 +38,9 @@ public class VersionService {
         Document document = documentRepository.findById(versionDTO.getDocumentId())
                 .orElseThrow(() -> new ResourceNotFoundException("Documento não encontrado"));
         
-        // Verificar permissões - apenas o estudante pode criar versões em documentos de rascunho ou revisão
-        if (!currentUser.getId().equals(document.getStudent().getId())) {
-            throw new RuntimeException("Apenas o estudante pode criar novas versões");
+        // Verificar permissões - apenas colaboradores com permissão de edição podem criar versões
+        if (!document.canUserEdit(currentUser)) {
+            throw new RuntimeException("Você não tem permissão para criar uma nova versão");
         }
         
         // Verificar se o documento está em status que permite novas versões

--- a/backend/com.tessera/src/test/java/com/tessera/backend/service/VersionServiceTest.java
+++ b/backend/com.tessera/src/test/java/com/tessera/backend/service/VersionServiceTest.java
@@ -1,0 +1,92 @@
+package com.tessera.backend.service;
+
+import com.tessera.backend.dto.VersionDTO;
+import com.tessera.backend.entity.*;
+import com.tessera.backend.repository.DocumentRepository;
+import com.tessera.backend.repository.VersionRepository;
+import com.tessera.backend.util.DiffUtils;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.*;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class VersionServiceTest {
+
+    @InjectMocks
+    private VersionService service;
+
+    @Mock
+    private VersionRepository versionRepository;
+    @Mock
+    private DocumentRepository documentRepository;
+    @Mock
+    private DiffUtils diffUtils;
+    @Mock
+    private NotificationEventService notificationEventService;
+
+    private Document document;
+    private User coauthor;
+
+    @BeforeEach
+    void setup() {
+        coauthor = createUser(2L, "Coauthor", "co@test.com", "STUDENT");
+
+        document = new Document();
+        document.setId(100L);
+        document.setStatus(DocumentStatus.DRAFT);
+
+        DocumentCollaborator collab = new DocumentCollaborator();
+        collab.setId(10L);
+        collab.setDocument(document);
+        collab.setUser(coauthor);
+        collab.setRole(CollaboratorRole.CO_STUDENT);
+        collab.setPermission(CollaboratorPermission.READ_WRITE);
+
+        document.setCollaborators(new ArrayList<>(List.of(collab)));
+    }
+
+    private User createUser(Long id, String name, String email, String roleName) {
+        User u = new User();
+        u.setId(id);
+        u.setName(name);
+        u.setEmail(email);
+        u.setPassword("pwd");
+        Role role = new Role(roleName);
+        u.setRoles(new HashSet<>(Set.of(role)));
+        return u;
+    }
+
+    @Test
+    void testCreateVersionByCoauthor() {
+        VersionDTO dto = new VersionDTO();
+        dto.setDocumentId(document.getId());
+        dto.setCommitMessage("init");
+        dto.setContent("content");
+
+        when(documentRepository.findById(document.getId())).thenReturn(Optional.of(document));
+        when(versionRepository.findByDocumentOrderByCreatedAtDesc(document)).thenReturn(Collections.emptyList());
+        when(versionRepository.findLatestByDocument(document)).thenReturn(Optional.empty());
+        when(versionRepository.save(any())).thenAnswer(inv -> {
+            Version v = inv.getArgument(0);
+            v.setId(1L);
+            return v;
+        });
+
+        VersionDTO result = service.createVersion(dto, coauthor);
+
+        assertEquals(1L, result.getId());
+        assertEquals("1.0", result.getVersionNumber());
+        assertEquals(coauthor.getId(), result.getCreatedById());
+        verify(versionRepository).save(any(Version.class));
+        verify(notificationEventService).onVersionCreated(any(Version.class), eq(coauthor));
+    }
+}


### PR DESCRIPTION
## Summary
- update version permissions so collaborators with edit access can create versions
- add tests for creating versions as a collaborator

## Testing
- `mvn test` *(fails: Non-resolvable parent POM - network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_683f9031af40832794b8646e7c830f3e