### PR TITLE
Remove legacy Document fields

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,3 +52,6 @@ Os arquivos de produção ficam em `dist/`.
 ---
 
 Com o backend e o frontend executando, acesse a interface em `http://localhost:3000` e utilize o sistema normalmente.
+
+### Database Migration
+A SQL script to migrate legacy `student_id` and `advisor_id` fields to the new `document_collaborators` table is available in `backend/db/migration/V1__migrate_student_advisor_to_collaborators.sql`.

--- a/backend/com.tessera/src/main/java/com/tessera/backend/controller/DocumentCollaboratorController.java
+++ b/backend/com.tessera/src/main/java/com/tessera/backend/controller/DocumentCollaboratorController.java
@@ -173,23 +173,4 @@ public class DocumentCollaboratorController {
         return ResponseEntity.ok(promotedCollaborator);
     }
     
-    @PostMapping("/migrate")
-    @Operation(summary = "Migrar documentos existentes", 
-               description = "Migra documentos existentes para o novo sistema de colaboradores (apenas admin)")
-    @ApiResponse(responseCode = "200", description = "Migração executada com sucesso")
-    public ResponseEntity<String> migrateExistingDocuments(Authentication authentication) {
-        User currentUser = getCurrentUser(authentication);
-        
-        // Verificar se é admin
-        boolean isAdmin = currentUser.getRoles().stream()
-                .anyMatch(role -> role.getName().equals("ADMIN"));
-        
-        if (!isAdmin) {
-            return ResponseEntity.status(HttpStatus.FORBIDDEN)
-                    .body("Apenas administradores podem executar a migração");
-        }
-        
-        collaboratorService.migrateExistingDocuments();
-        return ResponseEntity.ok("Migração executada com sucesso");
-    }
 }

--- a/backend/com.tessera/src/main/java/com/tessera/backend/dto/DocumentDTO.java
+++ b/backend/com.tessera/src/main/java/com/tessera/backend/dto/DocumentDTO.java
@@ -14,10 +14,6 @@ public class DocumentDTO {
     private String title;
     private String description;
     private DocumentStatus status;
-    private Long studentId;
-    private Long advisorId;
-    private String studentName;
-    private String advisorName;
     private LocalDateTime createdAt;
     private LocalDateTime updatedAt;
     private LocalDateTime submittedAt;

--- a/backend/com.tessera/src/main/java/com/tessera/backend/dto/DocumentDetailDTO.java
+++ b/backend/com.tessera/src/main/java/com/tessera/backend/dto/DocumentDetailDTO.java
@@ -38,8 +38,7 @@ public class DocumentDetailDTO extends DocumentDTO {
     // Construtor a partir de DocumentDTO
     public DocumentDetailDTO(DocumentDTO documentDTO) {
         super(documentDTO.getId(), documentDTO.getTitle(), documentDTO.getDescription(),
-              documentDTO.getStatus(), documentDTO.getStudentId(), documentDTO.getAdvisorId(),
-              documentDTO.getStudentName(), documentDTO.getAdvisorName(),
+              documentDTO.getStatus(),
               documentDTO.getCreatedAt(), documentDTO.getUpdatedAt(),
               documentDTO.getSubmittedAt(), documentDTO.getApprovedAt(),
               documentDTO.getRejectedAt(), documentDTO.getRejectionReason(),

--- a/backend/com.tessera/src/main/java/com/tessera/backend/entity/Document.java
+++ b/backend/com.tessera/src/main/java/com/tessera/backend/entity/Document.java
@@ -30,17 +30,8 @@ public class Document {
     
     @Column(columnDefinition = "TEXT")
     private String description;
-    
-    // CAMPOS MANTIDOS PARA COMPATIBILIDADE (serão gradualmente depreciados)
-    @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "student_id")
-    private User student;
-    
-    @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "advisor_id")
-    private User advisor;
-    
-    // NOVA RELAÇÃO PARA COLABORADORES MÚLTIPLOS
+
+    // Relação de colaboradores
     @OneToMany(mappedBy = "document", cascade = CascadeType.ALL, fetch = FetchType.LAZY)
     private List<DocumentCollaborator> collaborators = new ArrayList<>();
     
@@ -102,7 +93,7 @@ public class Document {
                 .filter(c -> c.isActive() && c.getRole() == CollaboratorRole.PRIMARY_STUDENT)
                 .map(DocumentCollaborator::getUser)
                 .findFirst()
-                .orElse(student); // Fallback para compatibilidade
+                .orElse(null);
     }
     
     /**
@@ -113,7 +104,7 @@ public class Document {
                 .filter(c -> c.isActive() && c.getRole() == CollaboratorRole.PRIMARY_ADVISOR)
                 .map(DocumentCollaborator::getUser)
                 .findFirst()
-                .orElse(advisor); // Fallback para compatibilidade
+                .orElse(null);
     }
     
     /**
@@ -201,9 +192,6 @@ public class Document {
      */
     public String getAllStudentNames() {
         List<User> students = getAllStudents();
-        if (students.isEmpty() && student != null) {
-            return student.getName();
-        }
         return students.stream()
                 .map(User::getName)
                 .collect(Collectors.joining(", "));
@@ -214,9 +202,6 @@ public class Document {
      */
     public String getAllAdvisorNames() {
         List<User> advisors = getAllAdvisors();
-        if (advisors.isEmpty() && advisor != null) {
-            return advisor.getName();
-        }
         return advisors.stream()
                 .map(User::getName)
                 .collect(Collectors.joining(", "));

--- a/backend/com.tessera/src/main/java/com/tessera/backend/repository/DocumentRepository.java
+++ b/backend/com.tessera/src/main/java/com/tessera/backend/repository/DocumentRepository.java
@@ -15,11 +15,7 @@ import java.util.List;
 @Repository
 public interface DocumentRepository extends JpaRepository<Document, Long> {
     
-    // Métodos existentes mantidos para compatibilidade
-    Page<Document> findByStudent(User student, Pageable pageable);
-    Page<Document> findByAdvisor(User advisor, Pageable pageable);
-    Page<Document> findByStudentAndStatus(User student, DocumentStatus status, Pageable pageable);
-    Page<Document> findByAdvisorAndStatus(User advisor, DocumentStatus status, Pageable pageable);
+
     
     // Novos métodos para busca por colaboradores
     @Query("SELECT DISTINCT d FROM Document d " +

--- a/backend/com.tessera/src/main/java/com/tessera/backend/service/CommentService.java
+++ b/backend/com.tessera/src/main/java/com/tessera/backend/service/CommentService.java
@@ -36,9 +36,11 @@ public class CommentService {
         
         Document document = version.getDocument();
         
-        // Verificar permissões - apenas orientador e aluno podem comentar
-        if (!currentUser.getId().equals(document.getStudent().getId()) && 
-            !currentUser.getId().equals(document.getAdvisor().getId())) {
+        // Verificar permissões - apenas colaboradores estudantes ou orientadores podem comentar
+        boolean allowed = document.getCollaborator(currentUser)
+                .map(c -> c.getRole().isStudent() || c.getRole().isAdvisor())
+                .orElse(false);
+        if (!allowed) {
             throw new RuntimeException("Você não tem permissão para comentar nesta versão");
         }
         
@@ -119,9 +121,11 @@ public class CommentService {
         
         Document document = comment.getVersion().getDocument();
         
-        // Verificar permissões - apenas orientador e aluno podem resolver comentários
-        if (!currentUser.getId().equals(document.getStudent().getId()) && 
-            !currentUser.getId().equals(document.getAdvisor().getId())) {
+        // Verificar permissões - apenas colaboradores estudantes ou orientadores podem resolver
+        boolean allowed = document.getCollaborator(currentUser)
+                .map(c -> c.getRole().isStudent() || c.getRole().isAdvisor())
+                .orElse(false);
+        if (!allowed) {
             throw new RuntimeException("Você não tem permissão para resolver este comentário");
         }
         
@@ -144,10 +148,12 @@ public class CommentService {
         
         Document document = comment.getVersion().getDocument();
         
-        // Verificar permissões - autor do comentário, orientador ou aluno podem deletar
-        if (!currentUser.getId().equals(comment.getUser().getId()) &&
-            !currentUser.getId().equals(document.getStudent().getId()) && 
-            !currentUser.getId().equals(document.getAdvisor().getId())) {
+        // Verificar permissões - autor do comentário, estudantes ou orientadores podem deletar
+        boolean allowed = currentUser.getId().equals(comment.getUser().getId()) ||
+                document.getCollaborator(currentUser)
+                        .map(c -> c.getRole().isStudent() || c.getRole().isAdvisor())
+                        .orElse(false);
+        if (!allowed) {
             throw new RuntimeException("Você não tem permissão para deletar este comentário");
         }
         

--- a/backend/com.tessera/src/main/java/com/tessera/backend/service/DocumentCollaboratorService.java
+++ b/backend/com.tessera/src/main/java/com/tessera/backend/service/DocumentCollaboratorService.java
@@ -246,46 +246,6 @@ public class DocumentCollaboratorService {
     /**
      * Migra documentos existentes para o sistema de colaboradores
      */
-    public void migrateExistingDocuments() {
-        List<Document> documents = documentRepository.findAll();
-        int migrated = 0;
-        
-        for (Document document : documents) {
-            boolean needsMigration = false;
-            
-            // Adicionar estudante principal se não existir como colaborador
-            if (document.getStudent() != null && !document.hasPrimaryStudent()) {
-                DocumentCollaborator studentCollaborator = new DocumentCollaborator();
-                studentCollaborator.setDocument(document);
-                studentCollaborator.setUser(document.getStudent());
-                studentCollaborator.setRole(CollaboratorRole.PRIMARY_STUDENT);
-                studentCollaborator.setPermission(CollaboratorPermission.FULL_ACCESS);
-                studentCollaborator.setAddedBy(document.getStudent());
-                collaboratorRepository.save(studentCollaborator);
-                needsMigration = true;
-            }
-            
-            // Adicionar orientador principal se não existir como colaborador
-            if (document.getAdvisor() != null && !document.hasPrimaryAdvisor()) {
-                DocumentCollaborator advisorCollaborator = new DocumentCollaborator();
-                advisorCollaborator.setDocument(document);
-                advisorCollaborator.setUser(document.getAdvisor());
-                advisorCollaborator.setRole(CollaboratorRole.PRIMARY_ADVISOR);
-                advisorCollaborator.setPermission(CollaboratorPermission.FULL_ACCESS);
-                advisorCollaborator.setAddedBy(document.getStudent());
-                collaboratorRepository.save(advisorCollaborator);
-                needsMigration = true;
-            }
-            
-            if (needsMigration) {
-                migrated++;
-            }
-        }
-        
-        System.out.println("Migração concluída: " + migrated + " documentos migrados");
-    }
-    
-    // =============================================================================
     // MÉTODOS AUXILIARES PRIVADOS
     // =============================================================================
     

--- a/backend/com.tessera/src/main/java/com/tessera/backend/service/NotificationEventService.java
+++ b/backend/com.tessera/src/main/java/com/tessera/backend/service/NotificationEventService.java
@@ -18,9 +18,10 @@ public class NotificationEventService {
     
     public void onDocumentCreated(Document document, User creator) {
         // Notificar orientador
-        if (document.getAdvisor() != null && !document.getAdvisor().equals(creator)) {
+        User advisor = document.getPrimaryAdvisor();
+        if (advisor != null && !advisor.equals(creator)) {
             sendNotification(
-                document.getAdvisor(),
+                advisor,
                 "Nova monografia criada",
                 String.format("O estudante %s criou uma nova monografia: '%s'", 
                              creator.getName(), document.getTitle()),

--- a/backend/com.tessera/src/main/java/com/tessera/backend/service/VersionService.java
+++ b/backend/com.tessera/src/main/java/com/tessera/backend/service/VersionService.java
@@ -38,9 +38,12 @@ public class VersionService {
         Document document = documentRepository.findById(versionDTO.getDocumentId())
                 .orElseThrow(() -> new ResourceNotFoundException("Documento não encontrado"));
         
-        // Verificar permissões - apenas o estudante pode criar versões em documentos de rascunho ou revisão
-        if (!currentUser.getId().equals(document.getStudent().getId())) {
-            throw new RuntimeException("Apenas o estudante pode criar novas versões");
+        // Verificar permissões - somente colaboradores estudantes podem criar novas versões
+        boolean allowed = document.getCollaborator(currentUser)
+                .map(c -> c.getRole().isStudent())
+                .orElse(false);
+        if (!allowed) {
+            throw new RuntimeException("Apenas estudantes podem criar novas versões");
         }
         
         // Verificar se o documento está em status que permite novas versões

--- a/backend/db/migration/V1__migrate_student_advisor_to_collaborators.sql
+++ b/backend/db/migration/V1__migrate_student_advisor_to_collaborators.sql
@@ -1,0 +1,23 @@
+-- Migrate legacy student/advisor columns to document_collaborators table
+-- Create collaborator rows for existing student_id and advisor_id values
+INSERT INTO document_collaborators (document_id, user_id, role, permission, added_at, active)
+SELECT d.id, d.student_id, 'PRIMARY_STUDENT', 'FULL_ACCESS', NOW(), true
+FROM documents d
+WHERE d.student_id IS NOT NULL
+  AND NOT EXISTS (
+    SELECT 1 FROM document_collaborators c
+    WHERE c.document_id = d.id AND c.user_id = d.student_id
+);
+
+INSERT INTO document_collaborators (document_id, user_id, role, permission, added_at, active)
+SELECT d.id, d.advisor_id, 'PRIMARY_ADVISOR', 'FULL_ACCESS', NOW(), true
+FROM documents d
+WHERE d.advisor_id IS NOT NULL
+  AND NOT EXISTS (
+    SELECT 1 FROM document_collaborators c
+    WHERE c.document_id = d.id AND c.user_id = d.advisor_id
+);
+
+-- Remove legacy columns
+ALTER TABLE documents DROP COLUMN IF EXISTS student_id;
+ALTER TABLE documents DROP COLUMN IF EXISTS advisor_id;


### PR DESCRIPTION
## Summary
- drop `student` and `advisor` from `Document`
- migrate existing references using Flyway-style SQL script
- rely on `DocumentCollaborator` in services
- update DTOs and repository
- adjust authorization checks for collaborators
- document migration procedure

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_683f9034069083278a20e21b06f099d9