### PR TITLE
Clean up repository interface comments

### DIFF
--- a/backend/com.tessera/src/main/java/com/tessera/backend/repository/DocumentCollaboratorRepository.java
+++ b/backend/com.tessera/src/main/java/com/tessera/backend/repository/DocumentCollaboratorRepository.java
@@ -1,4 +1,3 @@
-// Arquivo: scrs/src (cópia)/main/java/com/tessera/backend/repository/DocumentCollaboratorRepository.java
 package com.tessera.backend.repository;
 
 import com.tessera.backend.entity.Document;
@@ -65,6 +64,5 @@ public interface DocumentCollaboratorRepository extends JpaRepository<DocumentCo
            "GROUP BY c.role")
     List<Object[]> getCollaboratorStatsByDocument(@Param("document") Document document);
 
-    // NOVO MÉTODO ADICIONADO
     List<DocumentCollaborator> findAllByDocumentIdInAndActiveTrue(List<Long> documentIds);
 }

--- a/backend/com.tessera/src/main/java/com/tessera/backend/repository/RegistrationRequestRepository.java
+++ b/backend/com.tessera/src/main/java/com/tessera/backend/repository/RegistrationRequestRepository.java
@@ -16,5 +16,5 @@ public interface RegistrationRequestRepository extends JpaRepository<Registratio
 
     Optional<RegistrationRequest> findByUserId(Long userId);
 
-    long countByStatus(RequestStatus status); // <-- ADICIONE ESTE MÉTODO PARA CONTAGEM
+    long countByStatus(RequestStatus status);
 }


### PR DESCRIPTION
## Summary
- remove outdated header and inline comments from DocumentCollaboratorRepository and RegistrationRequestRepository

## Testing
- `./mvnw -q test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_683f957b68148327bde7cb67ee49b0f7