### PR TITLE
Remove temporary comments from backend files

### DIFF
--- a/backend/com.tessera/src/main/java/com/tessera/backend/config/SecurityConfig.java
+++ b/backend/com.tessera/src/main/java/com/tessera/backend/config/SecurityConfig.java
@@ -63,7 +63,7 @@ public class SecurityConfig {
                         "/v3/api-docs/**",
                         "/swagger-ui/**",
                         "/swagger-ui.html",
-                        "/ws/**" // <-- ADICIONE ESTA LINHA PARA PERMITIR ACESSO AOS ENDPOINTS WEBSOCKET/SOCKJS
+                        "/ws/**"
                 ).permitAll()
                 .requestMatchers("/admin/**").hasRole("ADMIN")
                 .requestMatchers("/advisor/**").hasRole("ADVISOR") 

--- a/backend/com.tessera/src/main/java/com/tessera/backend/controller/AdminController.java
+++ b/backend/com.tessera/src/main/java/com/tessera/backend/controller/AdminController.java
@@ -1,10 +1,9 @@
-// Arquivo: scrs/src/main/java/com/tessera/backend/controller/AdminController.java
 package com.tessera.backend.controller;
 
 import com.tessera.backend.dto.DashboardStatsDTO;
 import com.tessera.backend.dto.RegistrationApprovalDTO;
 import com.tessera.backend.dto.RegistrationRejectionDTO;
-import com.tessera.backend.dto.UserStatusUpdateDTO; // <-- IMPORTAÇÃO CORRIGIDA
+import com.tessera.backend.dto.UserStatusUpdateDTO;
 import com.tessera.backend.entity.RegistrationRequest;
 import com.tessera.backend.entity.User;
 import com.tessera.backend.repository.UserRepository;

--- a/backend/com.tessera/src/main/java/com/tessera/backend/controller/MetricsController.java
+++ b/backend/com.tessera/src/main/java/com/tessera/backend/controller/MetricsController.java
@@ -1,10 +1,9 @@
-// Arquivo: scrs/src/main/java/com/tessera/backend/controller/MetricsController.java
 package com.tessera.backend.controller;
 
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
-import org.springframework.http.ResponseEntity; // <-- IMPORTAÇÃO ADICIONADA
+import org.springframework.http.ResponseEntity;
 
 import java.util.HashMap;
 import java.util.Map;

--- a/backend/com.tessera/src/main/java/com/tessera/backend/controller/UserController.java
+++ b/backend/com.tessera/src/main/java/com/tessera/backend/controller/UserController.java
@@ -1,14 +1,13 @@
-// Arquivo: scrs/src (cópia)/main/java/com/tessera/backend/controller/UserController.java
 package com.tessera.backend.controller;
 
 import com.tessera.backend.dto.AdvisorDTO;
-import com.tessera.backend.dto.PasswordChangeDTO; // IMPORTAÇÃO ADICIONADA
+import com.tessera.backend.dto.PasswordChangeDTO;
 import com.tessera.backend.dto.UserSelectionDTO;
 import com.tessera.backend.entity.User;
 import com.tessera.backend.entity.UserStatus;
 import com.tessera.backend.repository.UserRepository;
 import com.tessera.backend.service.UserService;
-import jakarta.validation.Valid; // IMPORTAÇÃO ADICIONADA
+import jakarta.validation.Valid;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;

--- a/backend/com.tessera/src/main/java/com/tessera/backend/service/BackupService.java
+++ b/backend/com.tessera/src/main/java/com/tessera/backend/service/BackupService.java
@@ -1,5 +1,3 @@
-// Arquivo: scrs/src/main/java/com/tessera/backend/service/BackupService.java
-// src/main/java/com/tessera/backend/service/BackupService.java
 package com.tessera.backend.service;
 
 import org.springframework.beans.factory.annotation.Value;


### PR DESCRIPTION
## Summary
- clean up commented "Arquivo" headers and instruction comments

## Testing
- `./mvnw -q test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_683f957e3e5c832783bca60748410208