### PR TITLE
Clean up instructional comments

### DIFF
--- a/frontend/src/components/Layout/Sidebar.tsx
+++ b/frontend/src/components/Layout/Sidebar.tsx
@@ -1,4 +1,3 @@
-// src/components/Layout/Sidebar.tsx
 import React from 'react';
 import { Link, useLocation } from 'react-router-dom';
 import {
@@ -12,7 +11,7 @@ import {
   UserIcon,
   ClipboardDocumentListIcon,
   UsersIcon,
-  ChatBubbleLeftEllipsisIcon, // <-- Importar o ícone para comentários
+  ChatBubbleLeftEllipsisIcon,
 } from '@heroicons/react/24/outline';
 import { useAuthStore } from '../../store/authStore';
 
@@ -71,7 +70,7 @@ const Sidebar: React.FC<SidebarProps> = ({ open, setOpen }) => {
         {
           name: 'Meus Estudantes',
           href: '/advisor/students',
-          icon: AcademicCapIcon, // Poderia ser UserGroupIcon também
+          icon: AcademicCapIcon,
           current: location.pathname.startsWith('/advisor/students'),
         },
       ];
@@ -89,7 +88,7 @@ const Sidebar: React.FC<SidebarProps> = ({ open, setOpen }) => {
         {
           name: 'Novo Documento',
           href: '/student/documents/new',
-          icon: DocumentTextIcon, // Ou um ícone de "Plus" ou "Pencil"
+          icon: DocumentTextIcon,
           current: location.pathname === '/student/documents/new',
         },
       ];
@@ -105,7 +104,7 @@ const Sidebar: React.FC<SidebarProps> = ({ open, setOpen }) => {
       icon: BellIcon,
       current: location.pathname === '/notifications',
     },
-    { // NOVO ITEM ADICIONADO
+    {
       name: 'Meus Comentários',
       href: '/my-comments',
       icon: ChatBubbleLeftEllipsisIcon,

--- a/frontend/src/hooks/useModal.tsx
+++ b/frontend/src/hooks/useModal.tsx
@@ -1,4 +1,3 @@
-// Arquivo: srcs/src (cópia)/hooks/useModal.tsx
 import { useState, useCallback } from 'react';
 
 interface UseModalResult<T = any> {
@@ -22,8 +21,7 @@ export function useModal<T = any>(): UseModalResult<T> {
 
   const closeModal = useCallback(() => {
     setIsOpen(false);
-    // Opcionalmente, resete selectedItem apenas se não for uma reabertura rápida
-    // setSelectedItem(null); 
+    // setSelectedItem(null); // opcional
   }, []);
 
   return {

--- a/frontend/src/hooks/usePagination.tsx
+++ b/frontend/src/hooks/usePagination.tsx
@@ -1,4 +1,3 @@
-// Arquivo: srcs/src (cópia)/hooks/usePagination.tsx
 import { useState, useCallback, useEffect } from 'react';
 import { toast } from 'react-hot-toast';
 

--- a/frontend/src/lib/api.tsx
+++ b/frontend/src/lib/api.tsx
@@ -1,4 +1,3 @@
-// Arquivo: srcs/src (cópia)/lib/api.tsx
 import axios, { AxiosInstance, AxiosRequestConfig, AxiosResponse } from 'axios';
 import { toast } from 'react-hot-toast';
 import { toastManager } from '../utils/toastManager';

--- a/frontend/src/pages/DocumentEditPage.tsx
+++ b/frontend/src/pages/DocumentEditPage.tsx
@@ -1,4 +1,3 @@
-// Arquivo: srcs/src (cópia)/pages/DocumentEditPage.tsx
 import React, { useState, useEffect, useRef, useCallback } from 'react';
 import { useParams, useNavigate } from 'react-router-dom';
 import { useForm } from 'react-hook-form';
@@ -15,8 +14,7 @@ import { useAuthStore } from '../store/authStore';
 import { documentsApi, versionsApi, usersApi, DocumentDetailDTO, Version, UserSelection } from '../lib/api';
 import { toast } from 'react-hot-toast';
 import { debugLog } from '../utils/logger';
-// MODIFICAÇÃO: Importar TiptapEditor e sua EditorRef
-import TiptapEditor, { EditorRef } from '../Editor/TiptapEditor'; // Ajuste o caminho se necessário
+import TiptapEditor, { EditorRef } from '../Editor/TiptapEditor';
 import PageHeader from '../components/common/PageHeader';
 import LoadingSpinner from '../components/common/LoadingSpinner';
 import { useConfirmDialog } from '../hooks/useConfirmDialog';
@@ -45,7 +43,6 @@ interface FormData {
   advisorId: number | undefined;
 }
 
-// Componente do Formulário de Documento (sem alterações)
 const DocumentForm: React.FC<{
   register: any;
   errors: any;
@@ -121,7 +118,6 @@ const DocumentForm: React.FC<{
   );
 };
 
-// Componente do Editor de Documento - MODIFICADO para usar TiptapEditor
 const DocumentEditor: React.FC<{
   editorRef: React.RefObject<EditorRef>; // EditorRef agora é do Tiptap
   initialContent: string; // Será passado como 'content' para TiptapEditor
@@ -171,7 +167,6 @@ const DocumentEditor: React.FC<{
             Opcional, mas recomendado ao salvar alterações no conteúdo.
           </p>
         </div>
-        {/* MODIFICAÇÃO: Usando TiptapEditor */}
         <TiptapEditor
           ref={editorRef}
           content={initialContent} // Passa o conteúdo inicial
@@ -187,7 +182,6 @@ const DocumentEditor: React.FC<{
   );
 };
 
-// Componente de Indicador de Alterações Não Salvas (sem alterações)
 const UnsavedChangesIndicator: React.FC<{ hasChanges: boolean }> = ({ hasChanges }) => {
   if (!hasChanges) return null;
   return (
@@ -204,7 +198,7 @@ const DocumentEditPage: React.FC = () => {
   const navigate = useNavigate();
   const { user } = useAuthStore();
   const { confirmDeletion } = useConfirmDialog();
-  const editorRef = useRef<EditorRef>(null); // Agora será a ref para TiptapEditor
+  const editorRef = useRef<EditorRef>(null);
 
   const [latestVersion, setLatestVersion] = useState<Version | null>(null);
   const [editorInitialContent, setEditorInitialContent] = useState('');
@@ -443,7 +437,7 @@ const DocumentEditPage: React.FC = () => {
     }
   };
 
-  const handleDeleteDocument = async () => { /* ... (sem alterações) ... */
+  const handleDeleteDocument = async () => {
     if (!documentData) return;
     const confirmed = await confirmDeletion(documentData.title);
     if (!confirmed) return;
@@ -556,7 +550,6 @@ const DocumentEditPage: React.FC = () => {
           onFieldChange={handleFormChange}
           disabled={actionLoading || !canModifyDocument || advisorsLoading}
         />
-        {/* Componente DocumentEditor agora usa Tiptap internamente */}
         <DocumentEditor
           editorRef={editorRef}
           initialContent={editorInitialContent}

--- a/frontend/src/pages/admin/AdminUserListPage.tsx
+++ b/frontend/src/pages/admin/AdminUserListPage.tsx
@@ -1,4 +1,3 @@
-// Arquivo: srcs/src (cópia)/pages/admin/AdminUserListPage.tsx
 import React, { useState, useEffect, useCallback } from 'react';
 import {
   UsersIcon,


### PR DESCRIPTION
## Summary
- remove 'Arquivo:' and similar instructional comments from frontend source
- keep code unchanged
- run TypeScript build to ensure compilation succeeds

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_683f958353c883279e62e68b175d6641