### PR TITLE
Use custom exception hierarchy

### DIFF
--- a/backend/com.tessera/src/main/java/com/tessera/backend/exception/ApiException.java
+++ b/backend/com.tessera/src/main/java/com/tessera/backend/exception/ApiException.java
@@ -1,0 +1,10 @@
+package com.tessera.backend.exception;
+
+public abstract class ApiException extends RuntimeException {
+    public ApiException(String message) {
+        super(message);
+    }
+    public ApiException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/backend/com.tessera/src/main/java/com/tessera/backend/exception/BusinessRuleException.java
+++ b/backend/com.tessera/src/main/java/com/tessera/backend/exception/BusinessRuleException.java
@@ -1,0 +1,10 @@
+package com.tessera.backend.exception;
+
+public class BusinessRuleException extends ApiException {
+    public BusinessRuleException(String message) {
+        super(message);
+    }
+    public BusinessRuleException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/backend/com.tessera/src/main/java/com/tessera/backend/exception/GlobalExceptionHandler.java
+++ b/backend/com.tessera/src/main/java/com/tessera/backend/exception/GlobalExceptionHandler.java
@@ -53,6 +53,33 @@ public class GlobalExceptionHandler {
                 request.getDescription(false));
         return new ResponseEntity<>(errorDetails, HttpStatus.FORBIDDEN);
     }
+
+    @ExceptionHandler(NotFoundException.class)
+    public ResponseEntity<?> handleNotFound(NotFoundException ex, WebRequest request) {
+        ErrorDetails errorDetails = new ErrorDetails(
+                new Date(),
+                ex.getMessage(),
+                request.getDescription(false));
+        return new ResponseEntity<>(errorDetails, HttpStatus.NOT_FOUND);
+    }
+
+    @ExceptionHandler(PermissionDeniedException.class)
+    public ResponseEntity<?> handlePermissionDenied(PermissionDeniedException ex, WebRequest request) {
+        ErrorDetails errorDetails = new ErrorDetails(
+                new Date(),
+                ex.getMessage(),
+                request.getDescription(false));
+        return new ResponseEntity<>(errorDetails, HttpStatus.FORBIDDEN);
+    }
+
+    @ExceptionHandler(BusinessRuleException.class)
+    public ResponseEntity<?> handleBusinessRule(BusinessRuleException ex, WebRequest request) {
+        ErrorDetails errorDetails = new ErrorDetails(
+                new Date(),
+                ex.getMessage(),
+                request.getDescription(false));
+        return new ResponseEntity<>(errorDetails, HttpStatus.BAD_REQUEST);
+    }
     
     @ExceptionHandler(MethodArgumentNotValidException.class)
     public ResponseEntity<?> handleValidationExceptions(MethodArgumentNotValidException ex) {

--- a/backend/com.tessera/src/main/java/com/tessera/backend/exception/NotFoundException.java
+++ b/backend/com.tessera/src/main/java/com/tessera/backend/exception/NotFoundException.java
@@ -1,0 +1,10 @@
+package com.tessera.backend.exception;
+
+public class NotFoundException extends ApiException {
+    public NotFoundException(String message) {
+        super(message);
+    }
+    public NotFoundException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/backend/com.tessera/src/main/java/com/tessera/backend/exception/PermissionDeniedException.java
+++ b/backend/com.tessera/src/main/java/com/tessera/backend/exception/PermissionDeniedException.java
@@ -7,7 +7,7 @@ import org.springframework.web.bind.annotation.ResponseStatus;
  * Thrown when a user attempts an action without the required authorization.
  */
 @ResponseStatus(HttpStatus.FORBIDDEN)
-public class PermissionDeniedException extends RuntimeException {
+public class PermissionDeniedException extends ApiException {
     public PermissionDeniedException(String message) {
         super(message);
     }

--- a/backend/com.tessera/src/main/java/com/tessera/backend/exception/ResourceNotFoundException.java
+++ b/backend/com.tessera/src/main/java/com/tessera/backend/exception/ResourceNotFoundException.java
@@ -4,7 +4,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.ResponseStatus;
 
 @ResponseStatus(HttpStatus.NOT_FOUND)
-public class ResourceNotFoundException extends RuntimeException {
+public class ResourceNotFoundException extends NotFoundException {
     public ResourceNotFoundException(String message) {
         super(message);
     }

--- a/backend/com.tessera/src/main/java/com/tessera/backend/service/CommentService.java
+++ b/backend/com.tessera/src/main/java/com/tessera/backend/service/CommentService.java
@@ -14,6 +14,7 @@ import com.tessera.backend.entity.Document;
 import com.tessera.backend.entity.User;
 import com.tessera.backend.entity.Version;
 import com.tessera.backend.exception.ResourceNotFoundException;
+import com.tessera.backend.exception.PermissionDeniedException;
 import com.tessera.backend.repository.CommentRepository;
 import com.tessera.backend.repository.VersionRepository;
 
@@ -37,9 +38,9 @@ public class CommentService {
         Document document = version.getDocument();
         
         // Verificar permissões - apenas orientador e aluno podem comentar
-        if (!currentUser.getId().equals(document.getStudent().getId()) && 
+        if (!currentUser.getId().equals(document.getStudent().getId()) &&
             !currentUser.getId().equals(document.getAdvisor().getId())) {
-            throw new RuntimeException("Você não tem permissão para comentar nesta versão");
+            throw new PermissionDeniedException("Você não tem permissão para comentar nesta versão");
         }
         
         Comment comment = new Comment();
@@ -101,7 +102,7 @@ public class CommentService {
         
         // Verificar se o usuário é o autor do comentário
         if (!currentUser.getId().equals(comment.getUser().getId())) {
-            throw new RuntimeException("Você não tem permissão para editar este comentário");
+            throw new PermissionDeniedException("Você não tem permissão para editar este comentário");
         }
         
         comment.setContent(commentDTO.getContent());
@@ -120,9 +121,9 @@ public class CommentService {
         Document document = comment.getVersion().getDocument();
         
         // Verificar permissões - apenas orientador e aluno podem resolver comentários
-        if (!currentUser.getId().equals(document.getStudent().getId()) && 
+        if (!currentUser.getId().equals(document.getStudent().getId()) &&
             !currentUser.getId().equals(document.getAdvisor().getId())) {
-            throw new RuntimeException("Você não tem permissão para resolver este comentário");
+            throw new PermissionDeniedException("Você não tem permissão para resolver este comentário");
         }
         
         comment.setResolved(true);
@@ -146,9 +147,9 @@ public class CommentService {
         
         // Verificar permissões - autor do comentário, orientador ou aluno podem deletar
         if (!currentUser.getId().equals(comment.getUser().getId()) &&
-            !currentUser.getId().equals(document.getStudent().getId()) && 
+            !currentUser.getId().equals(document.getStudent().getId()) &&
             !currentUser.getId().equals(document.getAdvisor().getId())) {
-            throw new RuntimeException("Você não tem permissão para deletar este comentário");
+            throw new PermissionDeniedException("Você não tem permissão para deletar este comentário");
         }
         
         commentRepository.delete(comment);

--- a/backend/com.tessera/src/main/java/com/tessera/backend/service/VersionService.java
+++ b/backend/com.tessera/src/main/java/com/tessera/backend/service/VersionService.java
@@ -14,6 +14,8 @@ import com.tessera.backend.entity.DocumentStatus;
 import com.tessera.backend.entity.User;
 import com.tessera.backend.entity.Version;
 import com.tessera.backend.exception.ResourceNotFoundException;
+import com.tessera.backend.exception.PermissionDeniedException;
+import com.tessera.backend.exception.BusinessRuleException;
 import com.tessera.backend.repository.DocumentRepository;
 import com.tessera.backend.repository.VersionRepository;
 import com.tessera.backend.util.DiffUtils;
@@ -40,12 +42,12 @@ public class VersionService {
         
         // Verificar permissões - apenas colaboradores com permissão de edição podem criar versões
         if (!document.canUserEdit(currentUser)) {
-            throw new RuntimeException("Você não tem permissão para criar uma nova versão");
+            throw new PermissionDeniedException("Você não tem permissão para criar uma nova versão");
         }
         
         // Verificar se o documento está em status que permite novas versões
         if (document.getStatus() != DocumentStatus.DRAFT && document.getStatus() != DocumentStatus.REVISION) {
-            throw new RuntimeException("Novas versões só podem ser criadas em documentos em rascunho ou revisão");
+            throw new BusinessRuleException("Novas versões só podem ser criadas em documentos em rascunho ou revisão");
         }
         
         // Calcular número da versão

--- a/backend/com.tessera/src/test/java/com/tessera/backend/service/DocumentCollaboratorServiceTest.java
+++ b/backend/com.tessera/src/test/java/com/tessera/backend/service/DocumentCollaboratorServiceTest.java
@@ -7,6 +7,7 @@ import com.tessera.backend.repository.DocumentCollaboratorRepository;
 import com.tessera.backend.repository.DocumentRepository;
 import com.tessera.backend.repository.UserRepository;
 import com.tessera.backend.exception.PermissionDeniedException;
+import com.tessera.backend.exception.BusinessRuleException;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -205,7 +206,7 @@ class DocumentCollaboratorServiceTest {
                 .thenReturn(Optional.of(existing));
         when(collaboratorRepository.save(any())).thenThrow(new DataIntegrityViolationException("dup"));
 
-        RuntimeException ex = assertThrows(RuntimeException.class,
+        BusinessRuleException ex = assertThrows(BusinessRuleException.class,
                 () -> service.addCollaborator(100L, req, manager));
 
         assertEquals("Este usuário já é colaborador do documento", ex.getMessage());


### PR DESCRIPTION
## Summary
- add `ApiException` base and standard exceptions
- extend GlobalExceptionHandler for the new exceptions
- replace RuntimeException usage in service layer
- update related unit tests

## Testing
- `./mvnw -q test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_683fa34405048327a19bf6a19cb08076