### PR TITLE
Implement authorization checks using collaborators

### DIFF
--- a/backend/com.tessera/src/main/java/com/tessera/backend/service/AuthorizationService.java
+++ b/backend/com.tessera/src/main/java/com/tessera/backend/service/AuthorizationService.java
@@ -2,7 +2,11 @@ package com.tessera.backend.service;
 
 import com.tessera.backend.entity.Document; // e outras entidades necessárias
 import com.tessera.backend.entity.User;
+import com.tessera.backend.entity.DocumentCollaborator;
+import com.tessera.backend.entity.CollaboratorRole;
 import com.tessera.backend.repository.DocumentRepository;
+import com.tessera.backend.repository.DocumentCollaboratorRepository;
+import com.tessera.backend.repository.UserRepository;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.security.core.Authentication;
 import org.springframework.stereotype.Service;
@@ -13,39 +17,91 @@ public class AuthorizationService {
     @Autowired
     private DocumentRepository documentRepository; // Exemplo de dependência
 
+    @Autowired
+    private DocumentCollaboratorRepository collaboratorRepository;
+
+    @Autowired
+    private UserRepository userRepository;
+
     public boolean hasDocumentAccess(Authentication authentication, Long documentId) {
         if (authentication == null || !authentication.isAuthenticated()) {
             return false;
         }
-        String userEmail = authentication.getName();
-        // Lógica para verificar se o usuário (userEmail) tem acesso ao documentId
-        // Ex: buscar o documento e verificar se o usuário é um colaborador ativo.
-        // Esta é uma implementação de exemplo, ajuste conforme sua lógica de acesso.
+
+        User user = userRepository.findByEmail(authentication.getName()).orElse(null);
+        if (user == null) {
+            return false;
+        }
+
         Document document = documentRepository.findById(documentId).orElse(null);
         if (document == null) {
-            return false; // Ou lançar exceção se preferir que @PreAuthorize lide com 404
+            return false;
         }
-        // Exemplo simples: verificar se o email do usuário autenticado é o mesmo do estudante do documento
-        // OU se ele é um colaborador ativo. A lógica real deve usar o sistema de colaboradores.
-        // User currentUser = userRepository.findByEmail(userEmail).orElse(null);
-        // if(currentUser == null) return false;
-        // return document.hasCollaborator(currentUser);
-        // Por enquanto, para teste, pode retornar true se o documento existe:
-        return document != null; // Simplifique para testar se o serviço é chamado
+
+        return collaboratorRepository
+                .existsByDocumentAndUserAndActiveTrue(document, user);
     }
 
     // Implemente outros métodos como canEditDocument, canChangeDocumentStatus, etc.
     public boolean canEditDocument(Authentication authentication, Long documentId) {
-        // Sua lógica de permissão de edição
-        return true; // Placeholder
+        if (authentication == null || !authentication.isAuthenticated()) {
+            return false;
+        }
+
+        User user = userRepository.findByEmail(authentication.getName()).orElse(null);
+        if (user == null) {
+            return false;
+        }
+
+        Document document = documentRepository.findById(documentId).orElse(null);
+        if (document == null) {
+            return false;
+        }
+
+        return collaboratorRepository.findByDocumentAndUserAndActiveTrue(document, user)
+                .map(c -> c.getPermission().canWrite() && c.getRole().canEdit())
+                .orElse(false);
     }
 
     public boolean canChangeDocumentStatus(Authentication authentication, Long documentId) {
-        // Sua lógica
-        return true; // Placeholder
+        if (authentication == null || !authentication.isAuthenticated()) {
+            return false;
+        }
+
+        User user = userRepository.findByEmail(authentication.getName()).orElse(null);
+        if (user == null) {
+            return false;
+        }
+
+        Document document = documentRepository.findById(documentId).orElse(null);
+        if (document == null) {
+            return false;
+        }
+
+        return collaboratorRepository.findByDocumentAndUserAndActiveTrue(document, user)
+                .map(c -> c.getPermission().canManageCollaborators()
+                        || c.getRole().canManageCollaborators()
+                        || c.getRole().canSubmitDocument()
+                        || c.getRole().canApproveDocument())
+                .orElse(false);
     }
-     public boolean canDeleteDocument(Authentication authentication, Long documentId) {
-        // Sua lógica
-        return true; // Placeholder
+    public boolean canDeleteDocument(Authentication authentication, Long documentId) {
+        if (authentication == null || !authentication.isAuthenticated()) {
+            return false;
+        }
+
+        User user = userRepository.findByEmail(authentication.getName()).orElse(null);
+        if (user == null) {
+            return false;
+        }
+
+        Document document = documentRepository.findById(documentId).orElse(null);
+        if (document == null) {
+            return false;
+        }
+
+        return collaboratorRepository.findByDocumentAndUserAndActiveTrue(document, user)
+                .map(c -> c.getRole() == CollaboratorRole.PRIMARY_STUDENT)
+                .orElse(false);
     }
 }

--- a/backend/com.tessera/src/test/java/com/tessera/backend/service/AuthorizationServiceTest.java
+++ b/backend/com.tessera/src/test/java/com/tessera/backend/service/AuthorizationServiceTest.java
@@ -1,0 +1,111 @@
+package com.tessera.backend.service;
+
+import com.tessera.backend.entity.*;
+import com.tessera.backend.repository.DocumentCollaboratorRepository;
+import com.tessera.backend.repository.DocumentRepository;
+import com.tessera.backend.repository.UserRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.core.Authentication;
+
+import java.util.Optional;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class AuthorizationServiceTest {
+
+    @InjectMocks
+    private AuthorizationService service;
+
+    @Mock
+    private DocumentRepository documentRepository;
+    @Mock
+    private DocumentCollaboratorRepository collaboratorRepository;
+    @Mock
+    private UserRepository userRepository;
+
+    private Document document;
+    private User user;
+    private Authentication auth;
+
+    @BeforeEach
+    void setup() {
+        document = new Document();
+        document.setId(1L);
+
+        user = new User();
+        user.setId(10L);
+        user.setEmail("user@test.com");
+        user.setName("User");
+        user.setRoles(Set.of(new Role("STUDENT")));
+
+        auth = mock(Authentication.class);
+        when(auth.isAuthenticated()).thenReturn(true);
+        when(auth.getName()).thenReturn(user.getEmail());
+    }
+
+    @Test
+    void testHasDocumentAccessNoCollaborator() {
+        when(userRepository.findByEmail(user.getEmail())).thenReturn(Optional.of(user));
+        when(documentRepository.findById(document.getId())).thenReturn(Optional.of(document));
+        when(collaboratorRepository.existsByDocumentAndUserAndActiveTrue(document, user)).thenReturn(false);
+
+        assertFalse(service.hasDocumentAccess(auth, document.getId()));
+    }
+
+    @Test
+    void testCanEditDocumentWithoutPermission() {
+        DocumentCollaborator collab = new DocumentCollaborator();
+        collab.setDocument(document);
+        collab.setUser(user);
+        collab.setRole(CollaboratorRole.SECONDARY_STUDENT);
+        collab.setPermission(CollaboratorPermission.READ_ONLY);
+
+        when(userRepository.findByEmail(user.getEmail())).thenReturn(Optional.of(user));
+        when(documentRepository.findById(document.getId())).thenReturn(Optional.of(document));
+        when(collaboratorRepository.findByDocumentAndUserAndActiveTrue(document, user))
+                .thenReturn(Optional.of(collab));
+
+        assertFalse(service.canEditDocument(auth, document.getId()));
+    }
+
+    @Test
+    void testCanChangeStatusWithoutPermission() {
+        DocumentCollaborator collab = new DocumentCollaborator();
+        collab.setDocument(document);
+        collab.setUser(user);
+        collab.setRole(CollaboratorRole.OBSERVER);
+        collab.setPermission(CollaboratorPermission.READ_ONLY);
+
+        when(userRepository.findByEmail(user.getEmail())).thenReturn(Optional.of(user));
+        when(documentRepository.findById(document.getId())).thenReturn(Optional.of(document));
+        when(collaboratorRepository.findByDocumentAndUserAndActiveTrue(document, user))
+                .thenReturn(Optional.of(collab));
+
+        assertFalse(service.canChangeDocumentStatus(auth, document.getId()));
+    }
+
+    @Test
+    void testCanDeleteDocumentNotPrimaryStudent() {
+        DocumentCollaborator collab = new DocumentCollaborator();
+        collab.setDocument(document);
+        collab.setUser(user);
+        collab.setRole(CollaboratorRole.SECONDARY_STUDENT);
+        collab.setPermission(CollaboratorPermission.READ_WRITE);
+
+        when(userRepository.findByEmail(user.getEmail())).thenReturn(Optional.of(user));
+        when(documentRepository.findById(document.getId())).thenReturn(Optional.of(document));
+        when(collaboratorRepository.findByDocumentAndUserAndActiveTrue(document, user))
+                .thenReturn(Optional.of(collab));
+
+        assertFalse(service.canDeleteDocument(auth, document.getId()));
+    }
+}
+


### PR DESCRIPTION
## Summary
- implement permission checks in AuthorizationService
- add unit tests for denied access scenarios using collaborator rules

## Testing
- `./mvnw -q test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_683fa3431d788327ac05898e230a4c6e