### PR TITLE
Add dark mode toggle and fix notifications

### DIFF
--- a/backend/com.tessera/src/main/java/com/tessera/backend/service/NotificationEventService.java
+++ b/backend/com.tessera/src/main/java/com/tessera/backend/service/NotificationEventService.java
@@ -307,12 +307,12 @@ public class NotificationEventService {
     private void sendNotification(User user, String title, String message, String type) {
         // Log simples para debug
         logger.debug("NOTIFICAÇÃO [{}] para {}: {} - {}", type, user.getEmail(), title, message);
-        
+
         // Se o NotificationService estiver disponível, usar ele
         if (notificationService != null) {
             try {
-                // Aqui você pode implementar o envio real via NotificationService
-                // notificationService.createNotification(user, type, title, message, ...);
+                NotificationType notificationType = NotificationType.valueOf(type);
+                notificationService.createNotification(user, notificationType, title, message, null, null, null, null);
             } catch (Exception e) {
                 System.err.println("Erro ao enviar notificação: " + e.getMessage());
             }

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,11 +1,12 @@
 // src/App.tsx - CORRIGIDO
-import React, { Suspense } from 'react';
+import React, { Suspense, useEffect } from 'react';
 import { debugLog } from './utils/logger';
 import { BrowserRouter as Router, Routes, Route, Navigate } from 'react-router-dom';
 import { Toaster } from 'react-hot-toast';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { ReactQueryDevtools } from '@tanstack/react-query-devtools';
 import { useAuthStore } from './store/authStore';
+import { useThemeStore } from './store/themeStore';
 
 // Componentes de Layout e Proteção (carregados diretamente)
 import Layout from './components/Layout/Layout';
@@ -49,6 +50,16 @@ const queryClient = new QueryClient({
 
 const App: React.FC = () => {
   const { isAuthenticated } = useAuthStore();
+  const { theme } = useThemeStore();
+
+  useEffect(() => {
+    const root = document.documentElement;
+    if (theme === 'dark') {
+      root.classList.add('dark');
+    } else {
+      root.classList.remove('dark');
+    }
+  }, [theme]);
 
   debugLog('🚀 App renderizando', { isAuthenticated });
 

--- a/frontend/src/components/Layout/SettingsModal.tsx
+++ b/frontend/src/components/Layout/SettingsModal.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { XMarkIcon, Cog6ToothIcon } from '@heroicons/react/24/outline';
+import { useThemeStore } from '../../store/themeStore';
 
 interface SettingsModalProps {
   isOpen: boolean;
@@ -8,6 +9,15 @@ interface SettingsModalProps {
 
 const SettingsModal: React.FC<SettingsModalProps> = ({ isOpen, onClose }) => {
   if (!isOpen) return null;
+
+  const { theme, toggleTheme } = useThemeStore();
+
+  const ToggleSwitch: React.FC<{ enabled: boolean; onChange: () => void }> = ({ enabled, onChange }) => (
+    <label className="relative inline-flex items-center cursor-pointer">
+      <input type="checkbox" className="sr-only" checked={enabled} onChange={onChange} />
+      <div className="w-11 h-6 bg-gray-200 rounded-full peer-focus:outline-none peer-focus:ring-4 peer-focus:ring-primary-300 peer dark:bg-gray-700 peer-checked:bg-primary-600 after:content-[''] after:absolute after:top-[2px] after:left-[2px] after:bg-white after:border-gray-300 after:border after:rounded-full after:h-5 after:w-5 after:transition-all peer-checked:after:translate-x-full peer-checked:after:border-white"></div>
+    </label>
+  );
 
   return (
     <div className="fixed inset-0 bg-gray-600 bg-opacity-75 overflow-y-auto h-full w-full z-50 flex items-center justify-center p-4">
@@ -26,10 +36,11 @@ const SettingsModal: React.FC<SettingsModalProps> = ({ isOpen, onClose }) => {
             <span className="sr-only">Fechar modal</span>
           </button>
         </div>
-        <div className="p-6 space-y-4">
-          <p className="text-sm text-gray-600">
-            Em breve você poderá personalizar diversas opções de configuração.
-          </p>
+        <div className="p-6 space-y-6">
+          <div className="flex items-center justify-between">
+            <span className="text-sm font-medium text-gray-700">Modo escuro</span>
+            <ToggleSwitch enabled={theme === 'dark'} onChange={toggleTheme} />
+          </div>
         </div>
         <div className="flex items-center justify-end p-6 space-x-2 border-t border-gray-200 rounded-b">
           <button type="button" className="btn btn-primary" onClick={onClose}>

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -10,7 +10,7 @@
   }
   
   body {
-    @apply bg-gray-50 text-gray-900;
+    @apply bg-gray-50 text-gray-900 dark:bg-gray-900 dark:text-gray-100;
   }
 
   * {

--- a/frontend/src/store/themeStore.ts
+++ b/frontend/src/store/themeStore.ts
@@ -1,0 +1,24 @@
+import { create } from 'zustand';
+import { persist } from 'zustand/middleware';
+
+export type Theme = 'light' | 'dark';
+
+interface ThemeState {
+  theme: Theme;
+  toggleTheme: () => void;
+  setTheme: (theme: Theme) => void;
+}
+
+export const useThemeStore = create<ThemeState>()(
+  persist(
+    (set, get) => ({
+      theme: 'light',
+      toggleTheme: () => {
+        const newTheme = get().theme === 'light' ? 'dark' : 'light';
+        set({ theme: newTheme });
+      },
+      setTheme: (theme: Theme) => set({ theme })
+    }),
+    { name: 'theme-storage' }
+  )
+);

--- a/frontend/tailwind.config.js
+++ b/frontend/tailwind.config.js
@@ -1,5 +1,6 @@
 /** @type {import('tailwindcss').Config} */
 export default {
+  darkMode: 'class',
   content: [
     "./index.html",
     "./src/**/*.{js,ts,jsx,tsx}",


### PR DESCRIPTION
## Summary
- enable dark mode support in Tailwind and base styles
- add theme store and use it in App with HTML class switching
- provide Settings modal with dark mode toggle
- activate NotificationEventService to create notifications

## Testing
- `./mvnw -q test` *(fails: Non-resolvable parent POM)*
- `npm run lint` *(fails: cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_683fa64805e48327953ef99007252c08