### PR TITLE
Allow collaborators to update versions

### DIFF
--- a/backend/com.tessera/src/main/java/com/tessera/backend/controller/VersionController.java
+++ b/backend/com.tessera/src/main/java/com/tessera/backend/controller/VersionController.java
@@ -31,16 +31,27 @@ public class VersionController {
     
     @Autowired
     private UserRepository userRepository;
-    
+
     @PostMapping
     public ResponseEntity<VersionDTO> createVersion(
             @Valid @RequestBody VersionDTO versionDTO,
             Authentication authentication) {
         User currentUser = userRepository.findByEmail(authentication.getName())
                 .orElseThrow(() -> new RuntimeException("Usuário não encontrado"));
-        
+
         VersionDTO createdVersion = versionService.createVersion(versionDTO, currentUser);
         return new ResponseEntity<>(createdVersion, HttpStatus.CREATED);
+    }
+
+    @PutMapping("/{id}")
+    public ResponseEntity<VersionDTO> updateVersion(
+            @PathVariable Long id,
+            @Valid @RequestBody VersionDTO versionDTO,
+            Authentication authentication) {
+        User currentUser = userRepository.findByEmail(authentication.getName())
+                .orElseThrow(() -> new RuntimeException("Usuário não encontrado"));
+
+        return ResponseEntity.ok(versionService.updateVersion(id, versionDTO, currentUser));
     }
     
     @GetMapping("/{id}")

--- a/backend/com.tessera/src/test/java/com/tessera/backend/service/VersionServiceTest.java
+++ b/backend/com.tessera/src/test/java/com/tessera/backend/service/VersionServiceTest.java
@@ -89,4 +89,30 @@ class VersionServiceTest {
         verify(versionRepository).save(any(Version.class));
         verify(notificationEventService).onVersionCreated(any(Version.class), eq(coauthor));
     }
+
+    @Test
+    void testUpdateVersionByCoauthor() {
+        Version version = new Version();
+        version.setId(1L);
+        version.setDocument(document);
+        version.setVersionNumber("1.0");
+        version.setCommitMessage("old");
+        version.setContent("old");
+        version.setCreatedBy(coauthor);
+
+        VersionDTO dto = new VersionDTO();
+        dto.setCommitMessage("new msg");
+        dto.setContent("new content");
+
+        when(versionRepository.findById(1L)).thenReturn(Optional.of(version));
+        when(versionRepository.save(any())).thenAnswer(inv -> inv.getArgument(0));
+        when(diffUtils.generateDiff("old", "new content")).thenReturn("diff");
+
+        VersionDTO result = service.updateVersion(1L, dto, coauthor);
+
+        assertEquals("new msg", result.getCommitMessage());
+        assertEquals("new content", result.getContent());
+        assertEquals("diff", result.getDiffFromPrevious());
+        verify(versionRepository).save(version);
+    }
 }


### PR DESCRIPTION
## Summary
- add endpoint to update version data
- let service change commit message and content when authorized user updates a version
- test version update functionality

## Testing
- `./mvnw -q test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_683fa695df0083278d0361cdc8e94a3b