### PR TITLE
Add new service unit tests

### DIFF
--- a/backend/com.tessera/src/test/java/com/tessera/backend/service/AuthServiceTest.java
+++ b/backend/com.tessera/src/test/java/com/tessera/backend/service/AuthServiceTest.java
@@ -1,0 +1,114 @@
+package com.tessera.backend.service;
+
+import com.tessera.backend.dto.LoginRequestDTO;
+import com.tessera.backend.dto.LoginResponseDTO;
+import com.tessera.backend.dto.UserRegistrationDTO;
+import com.tessera.backend.entity.*;
+import com.tessera.backend.exception.EmailAlreadyExistsException;
+import com.tessera.backend.repository.RegistrationRequestRepository;
+import com.tessera.backend.repository.RoleRepository;
+import com.tessera.backend.repository.UserRepository;
+import com.tessera.backend.security.JwtTokenProvider;
+import com.tessera.backend.security.UserDetailsImpl;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class AuthServiceTest {
+
+    @InjectMocks
+    private AuthService service;
+
+    @Mock
+    private UserRepository userRepository;
+    @Mock
+    private RoleRepository roleRepository;
+    @Mock
+    private RegistrationRequestRepository registrationRequestRepository;
+    @Mock
+    private PasswordEncoder passwordEncoder;
+    @Mock
+    private AuthenticationManager authenticationManager;
+    @Mock
+    private JwtTokenProvider tokenProvider;
+    @Mock
+    private EmailService emailService;
+
+    private Role studentRole;
+    private User admin;
+
+    @BeforeEach
+    void setup() {
+        studentRole = new Role("STUDENT");
+        admin = new User();
+        admin.setEmail("admin@test.com");
+    }
+
+    @Test
+    void testRegisterUserSuccess() {
+        UserRegistrationDTO dto = new UserRegistrationDTO("User","user@test.com","pwd","STUDENT","inst","dept","just");
+
+        when(userRepository.existsByEmail(dto.getEmail())).thenReturn(false);
+        when(roleRepository.findByName("STUDENT")).thenReturn(Optional.of(studentRole));
+        when(passwordEncoder.encode("pwd")).thenReturn("encpwd");
+        when(userRepository.save(any(User.class))).thenAnswer(inv->{User u=inv.getArgument(0);u.setId(1L);return u;});
+        when(registrationRequestRepository.save(any())).thenAnswer(inv->inv.getArgument(0));
+        when(userRepository.findByRolesName("ADMIN")).thenReturn(List.of(admin));
+
+        User user = service.registerUser(dto);
+
+        assertEquals(1L, user.getId());
+        verify(emailService).sendNewRegistrationNotification(admin.getEmail(), user);
+        verify(registrationRequestRepository).save(any(RegistrationRequest.class));
+    }
+
+    @Test
+    void testRegisterUserDuplicateEmail() {
+        UserRegistrationDTO dto = new UserRegistrationDTO("User","dup@test.com","pwd","STUDENT","i","d","j");
+        when(userRepository.existsByEmail(dto.getEmail())).thenReturn(true);
+
+        assertThrows(EmailAlreadyExistsException.class, () -> service.registerUser(dto));
+    }
+
+    @Test
+    void testAuthenticateUser() {
+        LoginRequestDTO dto = new LoginRequestDTO("user@test.com","pwd");
+        User user = new User();
+        user.setId(5L);
+        user.setName("U");
+        user.setEmail(dto.getEmail());
+        user.setPassword("enc");
+        user.setRoles(Set.of(studentRole));
+        user.setStatus(UserStatus.APPROVED);
+
+        UserDetailsImpl details = UserDetailsImpl.build(user);
+        Authentication auth = new UsernamePasswordAuthenticationToken(details, null, details.getAuthorities());
+
+        when(authenticationManager.authenticate(any())).thenReturn(auth);
+        when(tokenProvider.generateToken(auth)).thenReturn("token");
+
+        LoginResponseDTO resp = service.authenticateUser(dto);
+
+        assertEquals("token", resp.getToken());
+        assertEquals(user.getId(), resp.getId());
+        assertEquals(List.of("ROLE_STUDENT"), resp.getRoles());
+    }
+}

--- a/backend/com.tessera/src/test/java/com/tessera/backend/service/NotificationServiceTest.java
+++ b/backend/com.tessera/src/test/java/com/tessera/backend/service/NotificationServiceTest.java
@@ -1,0 +1,119 @@
+package com.tessera.backend.service;
+
+import com.tessera.backend.dto.NotificationSummaryDTO;
+import com.tessera.backend.entity.*;
+import com.tessera.backend.repository.NotificationRepository;
+import com.tessera.backend.repository.UserNotificationSettingsRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.messaging.simp.SimpMessagingTemplate;
+
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class NotificationServiceTest {
+
+    @InjectMocks
+    private NotificationService service;
+
+    @Mock
+    private NotificationRepository notificationRepository;
+    @Mock
+    private UserNotificationSettingsRepository settingsRepository;
+    @Mock
+    private EmailService emailService;
+    @Mock
+    private SimpMessagingTemplate messagingTemplate;
+
+    private User user;
+    private UserNotificationSettings settings;
+
+    @BeforeEach
+    void setup() {
+        user = new User();
+        user.setId(1L);
+        user.setEmail("user@test.com");
+        user.setName("User");
+        settings = new UserNotificationSettings();
+        settings.setUser(user);
+        when(settingsRepository.findByUser(user)).thenReturn(Optional.of(settings));
+    }
+
+    @Test
+    void testCreateNotification() {
+        when(notificationRepository.save(any())).thenAnswer(inv->{Notification n=inv.getArgument(0);n.setId(1L);return n;});
+
+        service.createNotification(user, NotificationType.DOCUMENT_CREATED, "t","m", null, 1L, "document", "/d/1");
+
+        verify(notificationRepository).save(any(Notification.class));
+        verify(emailService).sendNotificationEmail(eq(user), any(Notification.class));
+        verify(messagingTemplate).convertAndSend(eq("/user/"+user.getEmail()+"/topic/notifications"), any());
+        verify(messagingTemplate).convertAndSend(eq("/user/"+user.getEmail()+"/topic/notification-summary"), any());
+    }
+
+    @Test
+    void testMarkAsRead() {
+        Notification n = new Notification();
+        n.setId(5L);
+        n.setUser(user);
+        n.setRead(false);
+        when(notificationRepository.findByIdAndUser(5L, user)).thenReturn(Optional.of(n));
+
+        service.markAsRead(5L, user);
+
+        assertTrue(n.isRead());
+        assertNotNull(n.getReadAt());
+        verify(notificationRepository).save(n);
+        verify(messagingTemplate).convertAndSend(eq("/user/"+user.getEmail()+"/topic/notification-summary"), any());
+    }
+
+    @Test
+    void testMarkAllAsRead() {
+        when(notificationRepository.markAllAsReadForUser(eq(user), any())).thenReturn(2);
+
+        service.markAllAsRead(user);
+
+        verify(messagingTemplate).convertAndSend(eq("/user/"+user.getEmail()+"/topic/notification-summary"), any());
+    }
+
+    @Test
+    void testGetNotificationSummary() {
+        List<Notification> unread = new ArrayList<>();
+        Notification n1 = new Notification();
+        n1.setPriority(NotificationPriority.NORMAL);
+        n1.setType(NotificationType.DOCUMENT_CREATED);
+        unread.add(n1);
+        Notification n2 = new Notification();
+        n2.setPriority(NotificationPriority.URGENT);
+        n2.setType(NotificationType.DOCUMENT_APPROVED);
+        unread.add(n2);
+        Notification n3 = new Notification();
+        n3.setPriority(NotificationPriority.NORMAL);
+        n3.setType(NotificationType.COMMENT_ADDED);
+        unread.add(n3);
+
+        when(notificationRepository.countByUserAndIsReadFalse(user)).thenReturn(3L);
+        when(notificationRepository.countByUser(user)).thenReturn(3L);
+        when(notificationRepository.findByUserAndIsReadFalseOrderByCreatedAtDesc(user)).thenReturn(unread);
+
+        NotificationSummaryDTO dto = service.getNotificationSummary(user);
+
+        assertEquals(3, dto.getUnreadCount());
+        assertTrue(dto.isHasUrgent());
+        assertEquals(2, dto.getDocumentsCount());
+        assertEquals(1, dto.getCommentsCount());
+        assertEquals(1, dto.getApprovalsCount());
+    }
+}


### PR DESCRIPTION
## Summary
- extend `DocumentServiceTest` with more scenarios
- add tests for `AuthService`
- add tests for `NotificationService`

## Testing
- `./backend/com.tessera/mvnw -q -f backend/com.tessera/pom.xml test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_683fa9eedf5c83278c4ada6c568da270