### PR TITLE
Improve keyboard navigation in user menu

### DIFF
--- a/frontend/src/components/Layout/Header.tsx
+++ b/frontend/src/components/Layout/Header.tsx
@@ -26,6 +26,47 @@ const Header: React.FC<HeaderProps> = ({ onMenuClick, onNotificationBellClick, o
   const navigate = useNavigate();
   const userMenuRef = useRef<HTMLDivElement>(null);
 
+  // Keyboard navigation and closing with Escape
+  useEffect(() => {
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (!userMenuOpen) return;
+
+      if (event.key === 'Escape') {
+        setUserMenuOpen(false);
+        return;
+      }
+
+      if (event.key === 'ArrowDown' || event.key === 'ArrowUp') {
+        event.preventDefault();
+        const items = userMenuRef.current?.querySelectorAll<HTMLElement>('a, button:not([disabled])');
+        if (!items || items.length === 0) return;
+
+        const currentIndex = Array.from(items).indexOf(document.activeElement as HTMLElement);
+        let nextIndex = 0;
+
+        if (event.key === 'ArrowDown') {
+          nextIndex = currentIndex === -1 || currentIndex === items.length - 1 ? 0 : currentIndex + 1;
+        } else {
+          nextIndex = currentIndex <= 0 ? items.length - 1 : currentIndex - 1;
+        }
+
+        items[nextIndex].focus();
+      }
+    };
+
+    document.addEventListener('keydown', handleKeyDown);
+    return () => {
+      document.removeEventListener('keydown', handleKeyDown);
+    };
+  }, [userMenuOpen]);
+
+  useEffect(() => {
+    if (userMenuOpen) {
+      const firstItem = userMenuRef.current?.querySelector<HTMLElement>('a, button:not([disabled])');
+      firstItem?.focus();
+    }
+  }, [userMenuOpen]);
+
   // Close user menu when clicking outside
   useEffect(() => {
     const handleClickOutside = (event: MouseEvent) => {
@@ -169,7 +210,7 @@ const Header: React.FC<HeaderProps> = ({ onMenuClick, onNotificationBellClick, o
 
                     <button
                       onClick={handleLogout}
-                      className="flex items-center w-full px-4 py-2 text-sm text-red-600 hover:bg-red-50"
+                      className="flex items-center w-full px-4 py-2 text-sm text-red-600 hover:bg-red-50 hover:text-red-700"
                     >
                       <ArrowRightOnRectangleIcon className="mr-3 h-5 w-5 text-red-400" />
                       Sair


### PR DESCRIPTION
## Summary
- close user menu on Esc and support arrow key navigation
- adjust hover colors for logout button to meet WCAG contrast

## Testing
- `npm test --silent` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_683fb6900148832790476e6f3272b760