### PR TITLE
Remove legacy collaborator migration

### DIFF
--- a/backend/com.tessera/src/main/java/com/tessera/backend/controller/DocumentCollaboratorController.java
+++ b/backend/com.tessera/src/main/java/com/tessera/backend/controller/DocumentCollaboratorController.java
@@ -173,23 +173,4 @@ public class DocumentCollaboratorController {
         return ResponseEntity.ok(promotedCollaborator);
     }
     
-    @PostMapping("/migrate")
-    @Operation(summary = "Migrar documentos existentes", 
-               description = "Migra documentos existentes para o novo sistema de colaboradores (apenas admin)")
-    @ApiResponse(responseCode = "200", description = "Migração executada com sucesso")
-    public ResponseEntity<String> migrateExistingDocuments(Authentication authentication) {
-        User currentUser = getCurrentUser(authentication);
-        
-        // Verificar se é admin
-        boolean isAdmin = currentUser.getRoles().stream()
-                .anyMatch(role -> role.getName().equals("ADMIN"));
-        
-        if (!isAdmin) {
-            return ResponseEntity.status(HttpStatus.FORBIDDEN)
-                    .body("Apenas administradores podem executar a migração");
-        }
-        
-        collaboratorService.migrateExistingDocuments();
-        return ResponseEntity.ok("Migração executada com sucesso");
-    }
 }

--- a/backend/com.tessera/src/main/java/com/tessera/backend/repository/DocumentRepository.java
+++ b/backend/com.tessera/src/main/java/com/tessera/backend/repository/DocumentRepository.java
@@ -81,7 +81,4 @@ public interface DocumentRepository extends JpaRepository<Document, Long> {
                                       @Param("status") DocumentStatus status,
                                       Pageable pageable);
 
-    // Recupera IDs de estudante e orientador legados para migração
-    @Query(value = "SELECT id, student_id, advisor_id FROM documents", nativeQuery = true)
-    List<Object[]> findLegacyCollaboratorIds();
 }

--- a/database/migrations/V2__drop_legacy_columns.sql
+++ b/database/migrations/V2__drop_legacy_columns.sql
@@ -1,0 +1,2 @@
+ALTER TABLE documents DROP COLUMN IF EXISTS student_id;
+ALTER TABLE documents DROP COLUMN IF EXISTS advisor_id;


### PR DESCRIPTION
## Summary
- drop old `findLegacyCollaboratorIds` query
- remove `migrateExistingDocuments` logic and controller endpoint
- add migration script to drop `student_id` and `advisor_id` columns

## Testing
- `./mvnw -q test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_683fb68dce40832785b676923e4cc2ef