### PR TITLE
Refine exception handling

### DIFF
--- a/backend/com.tessera/src/main/java/com/tessera/backend/config/DataInitializer.java
+++ b/backend/com.tessera/src/main/java/com/tessera/backend/config/DataInitializer.java
@@ -5,6 +5,7 @@ import com.tessera.backend.entity.User;
 import com.tessera.backend.entity.UserStatus;
 import com.tessera.backend.repository.RoleRepository;
 import com.tessera.backend.repository.UserRepository;
+import com.tessera.backend.exception.RoleNotFoundException;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.CommandLineRunner;
 import org.springframework.security.crypto.password.PasswordEncoder;
@@ -49,7 +50,7 @@ public class DataInitializer implements CommandLineRunner {
             adminUser.setApprovalDate(LocalDateTime.now());
             
             Role adminRole = roleRepository.findByName("ADMIN")
-                    .orElseThrow(() -> new RuntimeException("Role ADMIN não encontrada"));
+                    .orElseThrow(() -> new RoleNotFoundException("Role ADMIN não encontrada"));
             
             Set<Role> roles = new HashSet<>();
             roles.add(adminRole);

--- a/backend/com.tessera/src/main/java/com/tessera/backend/controller/CommentController.java
+++ b/backend/com.tessera/src/main/java/com/tessera/backend/controller/CommentController.java
@@ -22,6 +22,7 @@ import com.tessera.backend.dto.CommentDTO;
 import com.tessera.backend.entity.User;
 import com.tessera.backend.repository.UserRepository;
 import com.tessera.backend.service.CommentService;
+import com.tessera.backend.exception.ResourceNotFoundException;
 
 import jakarta.validation.Valid;
 
@@ -40,7 +41,7 @@ public class CommentController {
             @Valid @RequestBody CommentDTO commentDTO,
             Authentication authentication) {
         User currentUser = userRepository.findByEmail(authentication.getName())
-                .orElseThrow(() -> new RuntimeException("Usuário não encontrado"));
+                .orElseThrow(() -> new ResourceNotFoundException("Usuário não encontrado"));
         
         CommentDTO createdComment = commentService.createComment(commentDTO, currentUser);
         return new ResponseEntity<>(createdComment, HttpStatus.CREATED);
@@ -68,7 +69,7 @@ public class CommentController {
             Authentication authentication,
             Pageable pageable) {
         User currentUser = userRepository.findByEmail(authentication.getName())
-                .orElseThrow(() -> new RuntimeException("Usuário não encontrado"));
+                .orElseThrow(() -> new ResourceNotFoundException("Usuário não encontrado"));
         
         return ResponseEntity.ok(commentService.getCommentsByUser(currentUser, pageable));
     }
@@ -87,7 +88,7 @@ public class CommentController {
             @Valid @RequestBody CommentDTO commentDTO,
             Authentication authentication) {
         User currentUser = userRepository.findByEmail(authentication.getName())
-                .orElseThrow(() -> new RuntimeException("Usuário não encontrado"));
+                .orElseThrow(() -> new ResourceNotFoundException("Usuário não encontrado"));
         
         return ResponseEntity.ok(commentService.updateComment(id, commentDTO, currentUser));
     }
@@ -97,7 +98,7 @@ public class CommentController {
             @PathVariable Long id,
             Authentication authentication) {
         User currentUser = userRepository.findByEmail(authentication.getName())
-                .orElseThrow(() -> new RuntimeException("Usuário não encontrado"));
+                .orElseThrow(() -> new ResourceNotFoundException("Usuário não encontrado"));
         
         return ResponseEntity.ok(commentService.resolveComment(id, currentUser));
     }
@@ -107,7 +108,7 @@ public class CommentController {
             @PathVariable Long id,
             Authentication authentication) {
         User currentUser = userRepository.findByEmail(authentication.getName())
-                .orElseThrow(() -> new RuntimeException("Usuário não encontrado"));
+                .orElseThrow(() -> new ResourceNotFoundException("Usuário não encontrado"));
         
         commentService.deleteComment(id, currentUser);
         return ResponseEntity.noContent().build();

--- a/backend/com.tessera/src/main/java/com/tessera/backend/exception/GlobalExceptionHandler.java
+++ b/backend/com.tessera/src/main/java/com/tessera/backend/exception/GlobalExceptionHandler.java
@@ -10,6 +10,7 @@ import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ControllerAdvice;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.context.request.WebRequest;
+import com.tessera.backend.exception.RoleNotFoundException;
 
 import java.util.Date;
 import java.util.HashMap;
@@ -29,6 +30,15 @@ public class GlobalExceptionHandler {
     
     @ExceptionHandler(EmailAlreadyExistsException.class)
     public ResponseEntity<?> emailAlreadyExistsException(EmailAlreadyExistsException ex, WebRequest request) {
+        ErrorDetails errorDetails = new ErrorDetails(
+                new Date(),
+                ex.getMessage(),
+                request.getDescription(false));
+        return new ResponseEntity<>(errorDetails, HttpStatus.BAD_REQUEST);
+    }
+
+    @ExceptionHandler(RoleNotFoundException.class)
+    public ResponseEntity<?> roleNotFoundException(RoleNotFoundException ex, WebRequest request) {
         ErrorDetails errorDetails = new ErrorDetails(
                 new Date(),
                 ex.getMessage(),


### PR DESCRIPTION
## Summary
- use ResourceNotFoundException in CommentController
- throw RoleNotFoundException in DataInitializer
- map RoleNotFoundException in GlobalExceptionHandler

## Testing
- `./mvnw -q test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_683fb68eefb083279a69ef46751a99e6