### PR TITLE
Add editor presence broadcasting

### DIFF
--- a/backend/com.tessera/src/main/java/com/tessera/backend/controller/EditingSessionController.java
+++ b/backend/com.tessera/src/main/java/com/tessera/backend/controller/EditingSessionController.java
@@ -1,0 +1,44 @@
+package com.tessera.backend.controller;
+
+import java.security.Principal;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.messaging.handler.annotation.MessageMapping;
+import org.springframework.messaging.handler.annotation.Payload;
+import org.springframework.stereotype.Controller;
+
+import com.tessera.backend.dto.EditingSessionDTO;
+import com.tessera.backend.entity.User;
+import com.tessera.backend.repository.UserRepository;
+import com.tessera.backend.service.EditingSessionService;
+
+@Controller
+public class EditingSessionController {
+
+    @Autowired
+    private EditingSessionService editingSessionService;
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @MessageMapping("/editing/join")
+    public void joinEditing(@Payload EditingSessionDTO message, Principal principal) {
+        User user = getCurrentUser(principal);
+        if (message.getDocumentId() != null && user != null) {
+            editingSessionService.joinSession(message.getDocumentId(), user);
+        }
+    }
+
+    @MessageMapping("/editing/leave")
+    public void leaveEditing(@Payload EditingSessionDTO message, Principal principal) {
+        User user = getCurrentUser(principal);
+        if (message.getDocumentId() != null && user != null) {
+            editingSessionService.leaveSession(message.getDocumentId(), user);
+        }
+    }
+
+    private User getCurrentUser(Principal principal) {
+        if (principal == null) return null;
+        return userRepository.findByEmail(principal.getName()).orElse(null);
+    }
+}

--- a/backend/com.tessera/src/main/java/com/tessera/backend/dto/EditingSessionDTO.java
+++ b/backend/com.tessera/src/main/java/com/tessera/backend/dto/EditingSessionDTO.java
@@ -1,0 +1,14 @@
+package com.tessera.backend.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class EditingSessionDTO {
+    private Long documentId;
+    private Long userId;
+    private String userName;
+}

--- a/backend/com.tessera/src/main/java/com/tessera/backend/service/EditingSessionService.java
+++ b/backend/com.tessera/src/main/java/com/tessera/backend/service/EditingSessionService.java
@@ -1,0 +1,59 @@
+package com.tessera.backend.service;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Map;
+import java.util.stream.Collectors;
+import java.util.concurrent.ConcurrentHashMap;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.messaging.simp.SimpMessagingTemplate;
+import org.springframework.stereotype.Service;
+
+import com.tessera.backend.dto.EditingSessionDTO;
+import com.tessera.backend.entity.User;
+
+@Service
+public class EditingSessionService {
+
+    private final Map<Long, Map<Long, String>> activeEditors = new ConcurrentHashMap<>();
+
+    @Autowired
+    private SimpMessagingTemplate messagingTemplate;
+
+    public void joinSession(Long documentId, User user) {
+        activeEditors.computeIfAbsent(documentId, k -> new ConcurrentHashMap<>())
+                     .put(user.getId(), user.getName());
+        broadcast(documentId);
+    }
+
+    public void leaveSession(Long documentId, User user) {
+        Map<Long, String> map = activeEditors.get(documentId);
+        if (map != null) {
+            map.remove(user.getId());
+            if (map.isEmpty()) {
+                activeEditors.remove(documentId);
+            }
+            broadcast(documentId);
+        }
+    }
+
+    public boolean hasOtherEditors(Long documentId, Long userId) {
+        Map<Long, String> map = activeEditors.get(documentId);
+        if (map == null) return false;
+        return map.size() > 1 || (map.size() == 1 && !map.containsKey(userId));
+    }
+
+    public Collection<EditingSessionDTO> getEditors(Long documentId) {
+        Map<Long, String> map = activeEditors.getOrDefault(documentId, Collections.emptyMap());
+        return map.entrySet().stream()
+                   .map(e -> new EditingSessionDTO(documentId, e.getKey(), e.getValue()))
+                   .collect(Collectors.toList());
+    }
+
+    public void broadcast(Long documentId) {
+        Collection<EditingSessionDTO> editors = getEditors(documentId);
+        String destination = "/topic/documents/" + documentId + "/editors";
+        messagingTemplate.convertAndSend(destination, editors);
+    }
+}

--- a/backend/com.tessera/src/main/java/com/tessera/backend/service/VersionService.java
+++ b/backend/com.tessera/src/main/java/com/tessera/backend/service/VersionService.java
@@ -19,6 +19,7 @@ import com.tessera.backend.exception.BusinessRuleException;
 import com.tessera.backend.repository.DocumentRepository;
 import com.tessera.backend.repository.VersionRepository;
 import com.tessera.backend.util.DiffUtils;
+import com.tessera.backend.service.EditingSessionService;
 
 @Service
 public class VersionService {
@@ -34,6 +35,8 @@ public class VersionService {
     
     @Autowired
     private NotificationEventService notificationEventService;
+    @Autowired
+    private EditingSessionService editingSessionService;
 
     @Transactional
     public VersionDTO updateVersion(Long id, VersionDTO versionDTO, User currentUser) {
@@ -67,6 +70,9 @@ public class VersionService {
         // Verificar permissões - apenas colaboradores com permissão de edição podem criar versões
         if (!document.canUserEdit(currentUser)) {
             throw new PermissionDeniedException("Você não tem permissão para criar uma nova versão");
+        }
+        if (editingSessionService.hasOtherEditors(document.getId(), currentUser.getId())) {
+            throw new BusinessRuleException("Outro usuário está editando este documento.");
         }
         
         // Verificar se o documento está em status que permite novas versões


### PR DESCRIPTION
## Summary
- extend backend WebSocket support with editing session broadcasting
- show active editors in document edit page
- guard document and version updates when other editors are present

## Testing
- `./mvnw -q test` *(fails: Non-resolvable parent POM)*
- `npm test --silent` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_683fb6919f708327a3e29599f2d97644