### PR TITLE
Implement migration helper for legacy collaborator data

### DIFF
--- a/backend/com.tessera/src/main/java/com/tessera/backend/repository/DocumentRepository.java
+++ b/backend/com.tessera/src/main/java/com/tessera/backend/repository/DocumentRepository.java
@@ -81,4 +81,7 @@ public interface DocumentRepository extends JpaRepository<Document, Long> {
                                       @Param("status") DocumentStatus status,
                                       Pageable pageable);
 
+    @Query(value = "SELECT id, student_id, advisor_id FROM documents", nativeQuery = true)
+    List<Object[]> findLegacyCollaboratorIds();
+
 }

--- a/backend/com.tessera/src/main/java/com/tessera/backend/service/DocumentCollaboratorService.java
+++ b/backend/com.tessera/src/main/java/com/tessera/backend/service/DocumentCollaboratorService.java
@@ -185,8 +185,49 @@ public class DocumentCollaboratorService {
         
         collaborator.setPermission(newPermission);
         collaborator = collaboratorRepository.save(collaborator);
-        
+
         return mapToDTO(collaborator);
+    }
+
+    /**
+     * Popula colaboradores principais em documentos existentes baseados nos campos legados
+     * student_id e advisor_id.
+     */
+    @Transactional
+    public void migrateExistingDocuments() {
+        List<Object[]> rows = documentRepository.findLegacyCollaboratorIds();
+        for (Object[] r : rows) {
+            Long docId = ((Number) r[0]).longValue();
+            Long studentId = r[1] != null ? ((Number) r[1]).longValue() : null;
+            Long advisorId = r[2] != null ? ((Number) r[2]).longValue() : null;
+
+            Document document = documentRepository.findById(docId).orElse(null);
+            if (document == null) {
+                continue;
+            }
+
+            if (studentId != null && !document.hasPrimaryStudent()) {
+                userRepository.findById(studentId).ifPresent(student -> {
+                    DocumentCollaborator dc = new DocumentCollaborator();
+                    dc.setDocument(document);
+                    dc.setUser(student);
+                    dc.setRole(CollaboratorRole.PRIMARY_STUDENT);
+                    dc.setPermission(CollaboratorPermission.FULL_ACCESS);
+                    collaboratorRepository.save(dc);
+                });
+            }
+
+            if (advisorId != null && !document.hasPrimaryAdvisor()) {
+                userRepository.findById(advisorId).ifPresent(advisor -> {
+                    DocumentCollaborator dc = new DocumentCollaborator();
+                    dc.setDocument(document);
+                    dc.setUser(advisor);
+                    dc.setRole(CollaboratorRole.PRIMARY_ADVISOR);
+                    dc.setPermission(CollaboratorPermission.FULL_ACCESS);
+                    collaboratorRepository.save(dc);
+                });
+            }
+        }
     }
     
     /**


### PR DESCRIPTION
## Summary
- add `findLegacyCollaboratorIds` to `DocumentRepository`
- implement `migrateExistingDocuments` in `DocumentCollaboratorService`

## Testing
- `./mvnw -q test` *(fails: Non-resolvable parent POM - network unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68402632cdd883278759585a300795d6