### PR TITLE
Fix fetch event handler in service worker

### DIFF
--- a/frontend/public/sw.js
+++ b/frontend/public/sw.js
@@ -25,3 +25,4 @@ self.addEventListener('fetch', (event) => {
       }
     )
   );
+});


### PR DESCRIPTION
## Summary
- close the `fetch` event handler in `sw.js`

## Testing
- `npm test --silent` *(fails: `vitest` not found)*

------
https://chatgpt.com/codex/tasks/task_e_684029dd9dc083278e61ed2709f9bf1d