### PR TITLE
Switch to domain events for notifications

### DIFF
--- a/backend/com.tessera/src/main/java/com/tessera/backend/Application.java
+++ b/backend/com.tessera/src/main/java/com/tessera/backend/Application.java
@@ -2,8 +2,10 @@ package com.tessera.backend;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.scheduling.annotation.EnableAsync;
 
 @SpringBootApplication
+@EnableAsync
 public class Application {
 
 	public static void main(String[] args) {

--- a/backend/com.tessera/src/main/java/com/tessera/backend/event/NotificationEvent.java
+++ b/backend/com.tessera/src/main/java/com/tessera/backend/event/NotificationEvent.java
@@ -1,0 +1,20 @@
+package com.tessera.backend.event;
+
+import java.time.LocalDateTime;
+
+import com.tessera.backend.entity.NotificationPriority;
+import com.tessera.backend.entity.NotificationType;
+import com.tessera.backend.entity.User;
+
+public record NotificationEvent(
+        User user,
+        NotificationType type,
+        String title,
+        String message,
+        User triggeredBy,
+        Long entityId,
+        String entityType,
+        String actionUrl,
+        NotificationPriority priority,
+        LocalDateTime expiresAt
+) {}

--- a/backend/com.tessera/src/main/java/com/tessera/backend/service/NotificationEventListener.java
+++ b/backend/com.tessera/src/main/java/com/tessera/backend/service/NotificationEventListener.java
@@ -1,0 +1,32 @@
+package com.tessera.backend.service;
+
+import com.tessera.backend.event.NotificationEvent;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.transaction.event.TransactionalEventListener;
+import org.springframework.transaction.event.TransactionPhase;
+
+@Component
+public class NotificationEventListener {
+
+    @Autowired
+    private NotificationService notificationService;
+
+    @Async
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    public void handleNotification(NotificationEvent event) {
+        notificationService.createNotification(
+                event.user(),
+                event.type(),
+                event.title(),
+                event.message(),
+                event.triggeredBy(),
+                event.entityId(),
+                event.entityType(),
+                event.actionUrl(),
+                event.priority(),
+                event.expiresAt()
+        );
+    }
+}

--- a/backend/com.tessera/src/main/java/com/tessera/backend/service/NotificationEventService.java
+++ b/backend/com.tessera/src/main/java/com/tessera/backend/service/NotificationEventService.java
@@ -2,6 +2,7 @@ package com.tessera.backend.service;
 
 import com.tessera.backend.entity.*;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Service;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -13,8 +14,8 @@ public class NotificationEventService {
 
     private static final Logger logger = LoggerFactory.getLogger(NotificationEventService.class);
     
-    @Autowired(required = false)
-    private NotificationService notificationService;
+    @Autowired
+    private org.springframework.context.ApplicationEventPublisher eventPublisher;
     
     // =====================================================================
     // MÉTODOS PARA DOCUMENTOS
@@ -308,21 +309,18 @@ public class NotificationEventService {
         // Log simples para debug
         logger.debug("NOTIFICAÇÃO [{}] para {}: {} - {}", type, user.getEmail(), title, message);
 
-        // Se o NotificationService estiver disponível, usar ele
-        if (notificationService != null) {
-            try {
-                NotificationType notificationType = NotificationType.valueOf(type);
-                notificationService.createNotification(user, notificationType, title, message, null, null, null, null);
-            } catch (Exception e) {
-                System.err.println("Erro ao enviar notificação: " + e.getMessage());
-            }
-        }
-        
-        // Implementar outros canais de notificação aqui:
-        // - Email
-        // - Push notifications
-        // - WebSocket
-        // - SMS
-        // etc.
+        NotificationType notificationType = NotificationType.valueOf(type);
+        eventPublisher.publishEvent(new com.tessera.backend.event.NotificationEvent(
+                user,
+                notificationType,
+                title,
+                message,
+                null,
+                null,
+                null,
+                null,
+                com.tessera.backend.entity.NotificationPriority.NORMAL,
+                null
+        ));
     }
 }


### PR DESCRIPTION
## Summary
- publish `NotificationEvent` in `NotificationEventService`
- handle notification domain events asynchronously after commit
- enable async processing in the backend application

## Testing
- `mvnw -q test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_68402f8c91108327a210be7b2bcce1d7