### PR TITLE
Optimize version counting for document listings

### DIFF
--- a/backend/com.tessera/src/main/java/com/tessera/backend/repository/DocumentRepository.java
+++ b/backend/com.tessera/src/main/java/com/tessera/backend/repository/DocumentRepository.java
@@ -84,4 +84,15 @@ public interface DocumentRepository extends JpaRepository<Document, Long> {
     @Query(value = "SELECT id, student_id, advisor_id FROM documents", nativeQuery = true)
     List<Object[]> findLegacyCollaboratorIds();
 
+    // -------------------------------------------------------
+    // Utilidades para estatísticas de versão
+    // -------------------------------------------------------
+
+    /**
+     * Recupera a contagem de versões para um conjunto de documentos.
+     * Utiliza LEFT JOIN para considerar documentos sem versões registradas.
+     */
+    @Query("SELECT d.id, COUNT(v) FROM Document d LEFT JOIN d.versions v WHERE d.id IN :ids GROUP BY d.id")
+    List<Object[]> getVersionCounts(@Param("ids") List<Long> ids);
+
 }


### PR DESCRIPTION
## Summary
- add repository method `getVersionCounts` to fetch version totals for multiple documents
- use new method in `DocumentService` list operations
- overload `mapToDTO` so version count can be supplied without loading the versions collection

## Testing
- `./mvnw test` *(fails: Non-resolvable parent POM due to network)*
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68402f8db0648327b5323e1f3ca83f38