### PR TITLE
Enable caching for advisor list

### DIFF
--- a/backend/com.tessera/pom.xml
+++ b/backend/com.tessera/pom.xml
@@ -37,6 +37,10 @@
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-cache</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-mail</artifactId>
         </dependency>
         <dependency>

--- a/backend/com.tessera/src/main/java/com/tessera/backend/config/CacheConfig.java
+++ b/backend/com.tessera/src/main/java/com/tessera/backend/config/CacheConfig.java
@@ -1,0 +1,17 @@
+package com.tessera.backend.config;
+
+import org.springframework.cache.CacheManager;
+import org.springframework.cache.annotation.EnableCaching;
+import org.springframework.cache.concurrent.ConcurrentMapCacheManager;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@EnableCaching
+public class CacheConfig {
+
+    @Bean
+    public CacheManager cacheManager() {
+        return new ConcurrentMapCacheManager("approvedAdvisors");
+    }
+}

--- a/backend/com.tessera/src/main/java/com/tessera/backend/service/AdminService.java
+++ b/backend/com.tessera/src/main/java/com/tessera/backend/service/AdminService.java
@@ -16,6 +16,7 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.cache.annotation.CacheEvict;
 import org.springframework.util.StringUtils;
 import java.time.LocalDateTime;
 
@@ -35,6 +36,7 @@ public class AdminService {
     private NotificationEventService notificationEventService;
 
     @Transactional
+    @CacheEvict(value = "approvedAdvisors", allEntries = true)
     public void approveRegistration(Long requestId, User admin, RegistrationApprovalDTO approvalDTO) {
         RegistrationRequest request = registrationRequestRepository.findById(requestId)
                 .orElseThrow(() -> new ResourceNotFoundException("Solicitação de registro não encontrada"));
@@ -55,6 +57,7 @@ public class AdminService {
     }
 
     @Transactional
+    @CacheEvict(value = "approvedAdvisors", allEntries = true)
     public void rejectRegistration(Long requestId, User admin, RegistrationRejectionDTO rejectionDTO) {
         RegistrationRequest request = registrationRequestRepository.findById(requestId)
                 .orElseThrow(() -> new ResourceNotFoundException("Solicitação de registro não encontrada"));
@@ -74,6 +77,7 @@ public class AdminService {
     }
 
     @Transactional
+    @CacheEvict(value = "approvedAdvisors", allEntries = true)
     public void updateUserStatus(Long userId, User admin, UserStatusUpdateDTO statusUpdateDTO) {
         User user = userRepository.findById(userId)
                 .orElseThrow(() -> new ResourceNotFoundException("Usuário não encontrado com ID: " + userId));

--- a/backend/com.tessera/src/main/java/com/tessera/backend/service/AuthService.java
+++ b/backend/com.tessera/src/main/java/com/tessera/backend/service/AuthService.java
@@ -23,6 +23,7 @@ import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.cache.annotation.CacheEvict;
 
 import java.time.LocalDateTime;
 import java.util.HashSet;
@@ -55,6 +56,7 @@ public class AuthService {
     private EmailService emailService;
     
     @Transactional
+    @CacheEvict(value = "approvedAdvisors", allEntries = true)
     public User registerUser(UserRegistrationDTO registrationDTO) {
         // Verifica se email já existe
         if (userRepository.existsByEmail(registrationDTO.getEmail())) {

--- a/backend/com.tessera/src/main/java/com/tessera/backend/service/UserService.java
+++ b/backend/com.tessera/src/main/java/com/tessera/backend/service/UserService.java
@@ -20,6 +20,7 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.cache.annotation.Cacheable;
 import org.springframework.util.StringUtils;
 
 import java.util.ArrayList;
@@ -51,6 +52,7 @@ public class UserService {
         this.auditLogService = auditLogService;
     }
 
+    @Cacheable("approvedAdvisors")
     public List<AdvisorDTO> getApprovedAdvisors() {
         List<User> advisors = userRepository.findByRolesNameAndStatus("ADVISOR", UserStatus.APPROVED);
         return advisors.stream()


### PR DESCRIPTION
## Summary
- add Spring cache starter
- define CacheConfig with ConcurrentMapCacheManager
- cache results of `getApprovedAdvisors`
- invalidate advisor cache when user data changes

## Testing
- `./mvnw -q test` *(fails: Non-resolvable parent POM because network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68402f8f25d483279ff0b3fd1ab1f96c