### PR TITLE
Integrate comment thread into editor

### DIFF
--- a/frontend/src/Editor/TiptapEditor.tsx
+++ b/frontend/src/Editor/TiptapEditor.tsx
@@ -15,6 +15,7 @@ import TableHeader from '@tiptap/extension-table-header';
 import TableCell from '@tiptap/extension-table-cell';
 import Placeholder from '@tiptap/extension-placeholder';
 import CharacterCount from '@tiptap/extension-character-count';
+import { ChatBubbleLeftEllipsisIcon } from '@heroicons/react/24/outline';
 import {
   BoldIcon, ItalicIcon, UnderlineIcon, StrikethroughIcon, HighlighterIcon,
   AlignLeftIcon, AlignCenterIcon, AlignRightIcon, AlignJustifyIcon,
@@ -34,6 +35,7 @@ interface EditorProps {
   placeholder?: string;
   onChange: (content: string) => void;
   onSelectionChange?: (selection: { from: number; to: number }) => void;
+  onAddComment?: (selection: { from: number; to: number }) => void;
   editable?: boolean;
   className?: string;
   editorClassName?: string;
@@ -74,6 +76,7 @@ const TiptapEditor = forwardRef<EditorRef, EditorProps>(({
   placeholder = 'Escreva seu texto aqui...',
   onChange,
   onSelectionChange,
+  onAddComment,
   editable = true,
   className = '',
   editorClassName = 'min-h-[300px] max-h-[600px] overflow-y-auto custom-scrollbar',
@@ -258,6 +261,19 @@ const TiptapEditor = forwardRef<EditorRef, EditorProps>(({
           <button onClick={() => editor.chain().focus().toggleItalic().run()} disabled={!editable || !editor.can().chain().focus().toggleItalic().run()} className={`p-1.5 rounded ${editor.isActive('italic') ? 'bg-primary-500 text-white' : 'hover:bg-gray-700'} disabled:opacity-50`} title="Itálico (Ctrl+I)"><ItalicIcon size={16} /></button>
           <button onClick={() => editor.chain().focus().toggleUnderline().run()} disabled={!editable || !editor.can().chain().focus().toggleUnderline().run()} className={`p-1.5 rounded ${editor.isActive('underline') ? 'bg-primary-500 text-white' : 'hover:bg-gray-700'} disabled:opacity-50`} title="Sublinhado (Ctrl+U)"><UnderlineIcon size={16} /></button>
           <button onClick={() => editor.chain().focus().toggleStrike().run()} disabled={!editable || !editor.can().chain().focus().toggleStrike().run()} className={`p-1.5 rounded ${editor.isActive('strike') ? 'bg-primary-500 text-white' : 'hover:bg-gray-700'} disabled:opacity-50`} title="Riscado"><StrikethroughIcon size={16} /></button>
+          {onAddComment && (
+            <button
+              onClick={() => {
+                const { from, to } = editor.state.selection;
+                onAddComment({ from, to });
+              }}
+              disabled={!editable}
+              className="p-1.5 rounded hover:bg-gray-700 disabled:opacity-50"
+              title="Comentar seleção"
+            >
+              <ChatBubbleLeftEllipsisIcon className="h-4 w-4" />
+            </button>
+          )}
           <button onClick={() => { const previousUrl = editor.getAttributes('link').href; const url = window.prompt('URL do link:', previousUrl || 'https://'); if (url === null) return; if (url === '') { editor.chain().focus().extendMarkRange('link').unsetLink().run(); return; } editor.chain().focus().extendMarkRange('link').setLink({ href: url, target: '_blank' }).run();}} disabled={!editable} className={`p-1.5 rounded ${editor.isActive('link') ? 'bg-primary-500 text-white' : 'hover:bg-gray-700'} disabled:opacity-50`} title="Link"><LinkIcon size={16} /></button>
         </BubbleMenu>
       )}

--- a/frontend/src/pages/DocumentEditPage.tsx
+++ b/frontend/src/pages/DocumentEditPage.tsx
@@ -9,6 +9,8 @@ import {
   DocumentArrowUpIcon as SaveIcon,
   ClockIcon,
   TrashIcon,
+  ChatBubbleLeftEllipsisIcon,
+  XMarkIcon,
 } from '@heroicons/react/24/outline';
 import { useAuthStore } from '../store/authStore';
 import { documentsApi, versionsApi, DocumentDetailDTO, Version } from '../lib/api';
@@ -20,6 +22,7 @@ import LoadingSpinner from '../components/common/LoadingSpinner';
 import { useConfirmDialog } from '../hooks/useConfirmDialog';
 import { formatDateTime } from '../utils/dateUtils';
 import { useWebSocket } from '../components/providers/WebSocketProvider';
+import CommentThread from '../components/Comments/CommentThread';
 
 const schema = yup.object({
   title: yup
@@ -95,6 +98,8 @@ const DocumentEditor: React.FC<{
   commitMessage: string;
   setCommitMessage: (message: string) => void;
   onContentChange: (newContent: string) => void; // Será o 'onChange' do Tiptap
+  onSelectionChange?: (sel: { from: number; to: number }) => void;
+  onAddComment?: (sel: { from: number; to: number }) => void;
   isEditingDoc: boolean; // Renomeado para clareza, para diferenciar do 'editable' do Tiptap
   latestVersion?: Version | null;
   disabled?: boolean; // Para desabilitar campos e editor
@@ -104,6 +109,8 @@ const DocumentEditor: React.FC<{
   commitMessage,
   setCommitMessage,
   onContentChange,
+  onSelectionChange,
+  onAddComment,
   isEditingDoc,
   latestVersion,
   disabled = false,
@@ -142,6 +149,8 @@ const DocumentEditor: React.FC<{
           ref={editorRef}
           content={initialContent} // Passa o conteúdo inicial
           onChange={onContentChange} // Callback para mudanças
+          onSelectionChange={onSelectionChange}
+          onAddComment={onAddComment}
           placeholder="Comece a escrever seu documento aqui..."
           className="border border-gray-300 rounded-lg shadow-sm overflow-hidden" // Estilo para o wrapper do Tiptap
           editorClassName="min-h-[400px] p-4" // Estilo para a área de edição do Tiptap
@@ -178,6 +187,8 @@ const DocumentEditPage: React.FC = () => {
   const [actionLoading, setActionLoading] = useState(false);
   const [hasUnsavedChanges, setHasUnsavedChanges] = useState(false);
   const [activeEditors, setActiveEditors] = useState<{ id: number; name: string }[]>([]);
+  const [selection, setSelection] = useState<{ from: number; to: number } | null>(null);
+  const [isCommentPanelOpen, setIsCommentPanelOpen] = useState(false);
 
   const { sendMessage, subscribe } = useWebSocket();
 
@@ -515,11 +526,38 @@ const DocumentEditPage: React.FC = () => {
           commitMessage={commitMessage}
           setCommitMessage={setCommitMessage}
           onContentChange={handleEditorContentChange}
+          onSelectionChange={(sel) => setSelection(sel)}
+          onAddComment={(sel) => {
+            setSelection(sel);
+            setIsCommentPanelOpen(true);
+          }}
           isEditingDoc={isEditing}
           latestVersion={latestVersion}
           disabled={actionLoading || !canModifyDocument}
         />
       </form>
+
+      {isCommentPanelOpen && latestVersion && (
+        <div className="fixed inset-0 bg-gray-600 bg-opacity-50 overflow-y-auto z-40">
+          <div className="relative top-0 right-0 h-full w-full max-w-md ml-auto bg-white shadow-xl flex flex-col">
+            <div className="flex items-center justify-between p-4 border-b border-gray-200">
+              <h3 className="text-lg font-medium text-gray-900 flex items-center">
+                <ChatBubbleLeftEllipsisIcon className="h-5 w-5 mr-2" /> Comentários
+              </h3>
+              <button onClick={() => setIsCommentPanelOpen(false)} className="text-gray-400 hover:text-gray-600">
+                <XMarkIcon className="h-6 w-6" />
+              </button>
+            </div>
+            <div className="p-4 overflow-y-auto flex-1">
+              <CommentThread
+                versionId={latestVersion.id}
+                selectedPosition={selection || undefined}
+                onCommentAdded={() => setIsCommentPanelOpen(false)}
+              />
+            </div>
+          </div>
+        </div>
+      )}
     </div>
   );
 };


### PR DESCRIPTION
## Summary
- extend `TiptapEditor` to report selection and support a comment button
- display comment thread from `DocumentEditPage` using selected text

## Testing
- `npm run lint` *(fails: Invalid option)*
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_684441fcd5188327ad2e9a5c311a3f82