### PR TITLE
Fix editor ready state initialization

### DIFF
--- a/frontend/src/Editor/TiptapEditor.tsx
+++ b/frontend/src/Editor/TiptapEditor.tsx
@@ -103,11 +103,9 @@ const TiptapEditor = forwardRef<EditorRef, EditorProps>(({
     },
     onCreate: ({ editor: createdEditor}) => {
         // console.log("TiptapEditor: onCreate disparado");
-        setTimeout(() => {
-            if (!createdEditor.isDestroyed) {
-                setIsEditorReallyReady(true);
-            }
-        }, 50);
+        if (!createdEditor.isDestroyed) {
+            setIsEditorReallyReady(true);
+        }
     },
     onDestroy: () => {
         // console.log("TiptapEditor: onDestroy disparado");


### PR DESCRIPTION
## Summary
- remove `setTimeout` wrapper in Tiptap editor initialization
- check `isDestroyed` before calling `setIsEditorReallyReady`

## Testing
- `./mvnw test` *(fails: Non-resolvable parent POM)*
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684441f75db883278f45dc71faac57c8