### PR TITLE
Add LaTeX support to editor and viewer

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -8,6 +8,7 @@
       "name": "tessera-frontend",
       "version": "0.0.0",
       "dependencies": {
+        "@aarkue/tiptap-math-extension": "^1.3.6",
         "@headlessui/react": "^1.7.17",
         "@heroicons/react": "^2.0.18",
         "@hookform/resolvers": "^3.3.2",
@@ -32,6 +33,7 @@
         "@tiptap/react": "^2.1.13",
         "@tiptap/starter-kit": "^2.1.13",
         "axios": "^1.6.0",
+        "katex": "^0.16.22",
         "lucide-react": "^0.294.0",
         "quill": "^1.3.7",
         "react": "^18.2.0",
@@ -65,6 +67,20 @@
         "typescript": "^5.2.2",
         "vite": "^4.5.0",
         "vitest": "^1.0.0"
+      }
+    },
+    "node_modules/@aarkue/tiptap-math-extension": {
+      "version": "1.3.6",
+      "resolved": "https://registry.npmjs.org/@aarkue/tiptap-math-extension/-/tiptap-math-extension-1.3.6.tgz",
+      "integrity": "sha512-+wYePrAbziOmQfpbWMCiLth9IiirDr9r6DiMtz4kM8IYsZPSW4foUWQTSl5iu3bgDVY9oib9UWLlbOPrO4i1yg==",
+      "license": "MIT",
+      "dependencies": {
+        "evaluatex": "^2.2.0",
+        "katex": "^0.16.7"
+      },
+      "peerDependencies": {
+        "@tiptap/core": "^2.0.0",
+        "@tiptap/pm": "^2.0.0"
       }
     },
     "node_modules/@adobe/css-tools": {
@@ -423,6 +439,121 @@
       },
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@csstools/color-helpers": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-5.0.2.tgz",
+      "integrity": "sha512-JqWH1vsgdGcw2RR6VliXXdA0/59LttzlU8UlRT/iUUsEeWfYq8I+K0yhihEUTTHLRm1EXvpsCx3083EU15ecsA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@csstools/css-calc": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-2.1.4.tgz",
+      "integrity": "sha512-3N8oaj+0juUw/1H3YwmDDJXCgTB1gKU6Hc/bB502u9zR0q2vd786XJH9QfrKIEgFlZmhZiq6epXl4rHqhzsIgQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^3.0.5",
+        "@csstools/css-tokenizer": "^3.0.4"
+      }
+    },
+    "node_modules/@csstools/css-color-parser": {
+      "version": "3.0.10",
+      "resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-3.0.10.tgz",
+      "integrity": "sha512-TiJ5Ajr6WRd1r8HSiwJvZBiJOqtH86aHpUjq5aEKWHiII2Qfjqd/HCWKPOW8EP4vcspXbHnXrwIDlu5savQipg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/color-helpers": "^5.0.2",
+        "@csstools/css-calc": "^2.1.4"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^3.0.5",
+        "@csstools/css-tokenizer": "^3.0.4"
+      }
+    },
+    "node_modules/@csstools/css-parser-algorithms": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-3.0.5.tgz",
+      "integrity": "sha512-DaDeUkXZKjdGhgYaHNJTV9pV7Y9B3b644jCLs9Upc3VeNGg6LWARAT6O+Q+/COo+2gg/bM5rhpMAtf70WqfBdQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@csstools/css-tokenizer": "^3.0.4"
+      }
+    },
+    "node_modules/@csstools/css-tokenizer": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-3.0.4.tgz",
+      "integrity": "sha512-Vd/9EVDiu6PPJt9yAh6roZP6El1xHrdvIVGjyBsHR0RYwNHgL7FJPyIIW4fANJNG6FtyZfvlRPpFI4ZM/lubvw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@esbuild/aix-ppc64": {
@@ -4071,6 +4202,12 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/evaluatex": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/evaluatex/-/evaluatex-2.2.0.tgz",
+      "integrity": "sha512-QVtGvYTf9HvQyDjbBCwoDQPP9KMuVB56H8KalrkLsPPCQfngpVmkiIoxJ4FU/SVmlmhnbr/heOmP5VlbCTEJpg==",
+      "license": "MIT"
+    },
     "node_modules/eventemitter3": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-2.0.3.tgz",
@@ -5288,6 +5425,31 @@
       },
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/katex": {
+      "version": "0.16.22",
+      "resolved": "https://registry.npmjs.org/katex/-/katex-0.16.22.tgz",
+      "integrity": "sha512-XCHRdUw4lf3SKBaJe4EvgqIuWwkPSo9XoeO8GjQW94Bp7TWv9hNhzZjZ+OH9yf1UmLygb7DIT5GSFQiyt16zYg==",
+      "funding": [
+        "https://opencollective.com/katex",
+        "https://github.com/sponsors/katex"
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "commander": "^8.3.0"
+      },
+      "bin": {
+        "katex": "cli.js"
+      }
+    },
+    "node_modules/katex/node_modules/commander": {
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-8.3.0.tgz",
+      "integrity": "sha512-OkTL9umf+He2DZkUq8f8J9of7yL6RJKI24dVITBmNfZBmri9zYZQrKkuXiKhyfPSu8tUhnVBB1iKXevvnlR4Ww==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
       }
     },
     "node_modules/keyv": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -34,6 +34,8 @@
     "@tiptap/extension-underline": "^2.1.13",
     "@tiptap/react": "^2.1.13",
     "@tiptap/starter-kit": "^2.1.13",
+    "@aarkue/tiptap-math-extension": "^1.3.6",
+    "katex": "^0.16.22",
     "axios": "^1.6.0",
     "lucide-react": "^0.294.0",
     "quill": "^1.3.7",

--- a/frontend/src/Editor/TiptapEditor.tsx
+++ b/frontend/src/Editor/TiptapEditor.tsx
@@ -15,11 +15,14 @@ import TableHeader from '@tiptap/extension-table-header';
 import TableCell from '@tiptap/extension-table-cell';
 import Placeholder from '@tiptap/extension-placeholder';
 import CharacterCount from '@tiptap/extension-character-count';
+import MathExtension from '@aarkue/tiptap-math-extension';
+import 'katex/dist/katex.min.css';
 import {
   BoldIcon, ItalicIcon, UnderlineIcon, StrikethroughIcon, HighlighterIcon,
   AlignLeftIcon, AlignCenterIcon, AlignRightIcon, AlignJustifyIcon,
   ListIcon, ListOrderedIcon, QuoteIcon, CodeIcon, LinkIcon, ImageIcon,
-  TableIcon, UndoIcon, RedoIcon, Heading1Icon, Heading2Icon, Heading3Icon, PilcrowIcon
+  TableIcon, UndoIcon, RedoIcon, Heading1Icon, Heading2Icon, Heading3Icon, PilcrowIcon,
+  SigmaIcon, FunctionSquareIcon
 } from 'lucide-react';
 
 const LoadingSpinner: React.FC<{ message?: string }> = ({ message }) => (
@@ -67,6 +70,7 @@ const editorExtensionsConfig = (placeholderText: string, charLimit?: number) => 
   TableCell.configure({ HTMLAttributes: { class: 'border border-gray-300 p-2 align-top' } }),
   Placeholder.configure({ placeholder: placeholderText }),
   CharacterCount.configure({ limit: charLimit }),
+  MathExtension.configure({ evaluation: false }),
 ];
 
 const TiptapEditor = forwardRef<EditorRef, EditorProps>(({
@@ -178,6 +182,19 @@ const TiptapEditor = forwardRef<EditorRef, EditorProps>(({
     const setLinkCallback = () => { const previousUrl = editor.getAttributes('link').href; const url = window.prompt('Insira a URL do link:', previousUrl || 'https://'); if (url === null) return; if (url === '') { editor.chain().focus().extendMarkRange('link').unsetLink().run(); return; } editor.chain().focus().extendMarkRange('link').setLink({ href: url, target: '_blank' }).run(); };
     const addImageCallback = () => { const url = window.prompt('Insira a URL da imagem:'); if (url) { editor.chain().focus().setImage({ src: url }).run(); } };
     const insertTableCallback = () => editor.chain().focus().insertTable({ rows: 3, cols: 3, withHeaderRow: true }).run();
+    const insertInlineMath = () => {
+      const latex = window.prompt('Insira a expressão LaTeX:');
+      if (latex) {
+        editor.chain().focus().insertContent({ type: 'inlineMath', attrs: { latex, evaluate: 'no', display: 'no' } }).run();
+      }
+    };
+    const insertBlockMath = () => {
+      const latex = window.prompt('Insira a expressão LaTeX em bloco:');
+      if (latex) {
+        editor.chain().focus().insertContent({ type: 'inlineMath', attrs: { latex, evaluate: 'no', display: 'yes' } }).run();
+        editor.chain().focus().insertContent('<p></p>').run();
+      }
+    };
 
     return (
       <div className="editor-toolbar sticky top-0 z-10 bg-gray-50 border-b border-gray-200 p-1 sm:p-2 flex flex-wrap items-center gap-x-1 gap-y-0.5 min-h-[46px]">
@@ -214,6 +231,8 @@ const TiptapEditor = forwardRef<EditorRef, EditorProps>(({
           <ToolbarButton onClick={setLinkCallback} isActive={editor.isActive('link')} title="Inserir/Editar Link"><LinkIcon size={18} /></ToolbarButton>
           <ToolbarButton onClick={addImageCallback} title="Inserir Imagem"><ImageIcon size={18} /></ToolbarButton>
           <ToolbarButton onClick={insertTableCallback} title="Inserir Tabela"><TableIcon size={18} /></ToolbarButton>
+          <ToolbarButton onClick={insertInlineMath} title="Equação Inline"><FunctionSquareIcon size={18} /></ToolbarButton>
+          <ToolbarButton onClick={insertBlockMath} title="Equação em Bloco"><SigmaIcon size={18} /></ToolbarButton>
         </div>
       </div>
     );

--- a/frontend/src/pages/DocumentViewPage.tsx
+++ b/frontend/src/pages/DocumentViewPage.tsx
@@ -17,6 +17,7 @@ import {
 import { useAuthStore } from '../store/authStore';
 import { documentsApi, versionsApi, DocumentDetailDTO as ApiDocumentDetailDTO } from '../lib/api';
 import { toast } from 'react-hot-toast';
+import 'katex/dist/katex.min.css';
 
 // Componentes otimizados
 import PageHeader from '../components/common/PageHeader';

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -2,6 +2,14 @@
 # yarn lockfile v1
 
 
+"@aarkue/tiptap-math-extension@^1.3.6":
+  version "1.3.6"
+  resolved "https://registry.npmjs.org/@aarkue/tiptap-math-extension/-/tiptap-math-extension-1.3.6.tgz"
+  integrity sha512-+wYePrAbziOmQfpbWMCiLth9IiirDr9r6DiMtz4kM8IYsZPSW4foUWQTSl5iu3bgDVY9oib9UWLlbOPrO4i1yg==
+  dependencies:
+    evaluatex "^2.2.0"
+    katex "^0.16.7"
+
 "@adobe/css-tools@^4.4.0":
   version "4.4.3"
   resolved "https://registry.npmjs.org/@adobe/css-tools/-/css-tools-4.4.3.tgz"
@@ -197,6 +205,34 @@
   dependencies:
     "@babel/helper-string-parser" "^7.27.1"
     "@babel/helper-validator-identifier" "^7.27.1"
+
+"@csstools/color-helpers@^5.0.2":
+  version "5.0.2"
+  resolved "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-5.0.2.tgz"
+  integrity sha512-JqWH1vsgdGcw2RR6VliXXdA0/59LttzlU8UlRT/iUUsEeWfYq8I+K0yhihEUTTHLRm1EXvpsCx3083EU15ecsA==
+
+"@csstools/css-calc@^2.1.3", "@csstools/css-calc@^2.1.4":
+  version "2.1.4"
+  resolved "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-2.1.4.tgz"
+  integrity sha512-3N8oaj+0juUw/1H3YwmDDJXCgTB1gKU6Hc/bB502u9zR0q2vd786XJH9QfrKIEgFlZmhZiq6epXl4rHqhzsIgQ==
+
+"@csstools/css-color-parser@^3.0.9":
+  version "3.0.10"
+  resolved "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-3.0.10.tgz"
+  integrity sha512-TiJ5Ajr6WRd1r8HSiwJvZBiJOqtH86aHpUjq5aEKWHiII2Qfjqd/HCWKPOW8EP4vcspXbHnXrwIDlu5savQipg==
+  dependencies:
+    "@csstools/color-helpers" "^5.0.2"
+    "@csstools/css-calc" "^2.1.4"
+
+"@csstools/css-parser-algorithms@^3.0.4", "@csstools/css-parser-algorithms@^3.0.5":
+  version "3.0.5"
+  resolved "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-3.0.5.tgz"
+  integrity sha512-DaDeUkXZKjdGhgYaHNJTV9pV7Y9B3b644jCLs9Upc3VeNGg6LWARAT6O+Q+/COo+2gg/bM5rhpMAtf70WqfBdQ==
+
+"@csstools/css-tokenizer@^3.0.3", "@csstools/css-tokenizer@^3.0.4":
+  version "3.0.4"
+  resolved "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-3.0.4.tgz"
+  integrity sha512-Vd/9EVDiu6PPJt9yAh6roZP6El1xHrdvIVGjyBsHR0RYwNHgL7FJPyIIW4fANJNG6FtyZfvlRPpFI4ZM/lubvw==
 
 "@esbuild/aix-ppc64@0.21.5":
   version "0.21.5"
@@ -776,7 +812,7 @@
     "@testing-library/dom" "^9.0.0"
     "@types/react-dom" "^18.0.0"
 
-"@tiptap/core@^2.12.0", "@tiptap/core@^2.7.0":
+"@tiptap/core@^2.0.0", "@tiptap/core@^2.12.0", "@tiptap/core@^2.7.0":
   version "2.12.0"
   resolved "https://registry.npmjs.org/@tiptap/core/-/core-2.12.0.tgz"
   integrity sha512-3qX8oGVKFFZzQ0vit+ZolR6AJIATBzmEmjAA0llFhWk4vf3v64p1YcXcJsOBsr5scizJu5L6RYWEFatFwqckRg==
@@ -952,7 +988,7 @@
   resolved "https://registry.npmjs.org/@tiptap/extension-underline/-/extension-underline-2.12.0.tgz"
   integrity sha512-u95lrUCesw1SN3BXY4xrgfSuxtoCYmJ9uaU7IVVOu0zVsDFtLlOa82kd63KVF+URL0kMdO+FBmvdS6d8Era70Q==
 
-"@tiptap/pm@^2.12.0", "@tiptap/pm@^2.7.0":
+"@tiptap/pm@^2.0.0", "@tiptap/pm@^2.12.0", "@tiptap/pm@^2.7.0":
   version "2.12.0"
   resolved "https://registry.npmjs.org/@tiptap/pm/-/pm-2.12.0.tgz"
   integrity sha512-TNzVwpeNzFfHAcYTOKqX9iU4fRxliyoZrCnERR+RRzeg7gWrXrCLubQt1WEx0sojMAfznshSL3M5HGsYjEbYwA==
@@ -1599,6 +1635,11 @@ commander@^4.0.0:
   resolved "https://registry.npmjs.org/commander/-/commander-4.1.1.tgz"
   integrity sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA==
 
+commander@^8.3.0:
+  version "8.3.0"
+  resolved "https://registry.npmjs.org/commander/-/commander-8.3.0.tgz"
+  integrity sha512-OkTL9umf+He2DZkUq8f8J9of7yL6RJKI24dVITBmNfZBmri9zYZQrKkuXiKhyfPSu8tUhnVBB1iKXevvnlR4Ww==
+
 concat-map@0.0.1:
   version "0.0.1"
   resolved "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
@@ -2050,6 +2091,11 @@ esutils@^2.0.2:
   version "2.0.3"
   resolved "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz"
   integrity sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==
+
+evaluatex@^2.2.0:
+  version "2.2.0"
+  resolved "https://registry.npmjs.org/evaluatex/-/evaluatex-2.2.0.tgz"
+  integrity sha512-QVtGvYTf9HvQyDjbBCwoDQPP9KMuVB56H8KalrkLsPPCQfngpVmkiIoxJ4FU/SVmlmhnbr/heOmP5VlbCTEJpg==
 
 eventemitter3@^2.0.3:
   version "2.0.3"
@@ -2714,6 +2760,13 @@ json5@^2.2.3:
   version "2.2.3"
   resolved "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz"
   integrity sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==
+
+katex@^0.16.22, katex@^0.16.7:
+  version "0.16.22"
+  resolved "https://registry.npmjs.org/katex/-/katex-0.16.22.tgz"
+  integrity sha512-XCHRdUw4lf3SKBaJe4EvgqIuWwkPSo9XoeO8GjQW94Bp7TWv9hNhzZjZ+OH9yf1UmLygb7DIT5GSFQiyt16zYg==
+  dependencies:
+    commander "^8.3.0"
 
 keyv@^4.5.3:
   version "4.5.4"


### PR DESCRIPTION
## Summary
- install `@aarkue/tiptap-math-extension` and `katex`
- enable math extension in TipTap editor
- add toolbar buttons for inline and block equations
- load KaTeX CSS on document view page so saved math renders correctly

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684441fea4cc83279a7eb965e47c3b51