### PR TITLE
Update dev server port references

### DIFF
--- a/backend/com.tessera/src/main/java/com/tessera/backend/config/SecurityConfig.java
+++ b/backend/com.tessera/src/main/java/com/tessera/backend/config/SecurityConfig.java
@@ -83,7 +83,7 @@ public class SecurityConfig {
         CorsConfiguration config = new CorsConfiguration();
         config.setAllowCredentials(true);
         // config.addAllowedOrigin("http://localhost:3000"); // Se ainda usar
-        config.addAllowedOrigin("http://localhost:5173"); // Frontend URL Vite
+        config.addAllowedOrigin("http://localhost:3000"); // Frontend URL Vite
         config.addAllowedOriginPattern("*"); // Para desenvolvimento, pode ser mais permissivo, mas restrinja em produção
         config.addAllowedHeader("*");
         config.addAllowedMethod("*");
@@ -97,7 +97,7 @@ public class SecurityConfig {
         CorsConfiguration config = new CorsConfiguration();
         config.setAllowCredentials(true);
         // config.addAllowedOrigin("http://localhost:3000");
-        config.addAllowedOrigin("http://localhost:5173");
+        config.addAllowedOrigin("http://localhost:3000");
         config.addAllowedOriginPattern("*"); // Adicionado para flexibilidade em dev
         config.addAllowedHeader("*");
         config.addAllowedMethod("*");

--- a/backend/com.tessera/src/main/java/com/tessera/backend/service/EmailService.java
+++ b/backend/com.tessera/src/main/java/com/tessera/backend/service/EmailService.java
@@ -138,7 +138,7 @@ public class EmailService {
         
         if (notification.getActionUrl() != null && !notification.getActionUrl().isEmpty()) {
             messageText += "Para mais detalhes, acesse: " + 
-                          "http://localhost:5173" + notification.getActionUrl() + "\n\n";
+                            "http://localhost:3000" + notification.getActionUrl() + "\n\n";
         }
         
         if (notification.getTriggeredBy() != null) {

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -184,7 +184,7 @@ npm run dev
 yarn dev
 ```
 
-O frontend estará disponível em `http://localhost:5173`
+O frontend estará disponível em `http://localhost:3000`
 
 ## 👤 Usuários Padrão
 


### PR DESCRIPTION
## Summary
- update local dev server port to 3000 in documentation
- update backend CORS configuration to allow localhost:3000
- update email notification links to localhost:3000

## Testing
- `./mvnw test -q` *(fails: Non-resolvable parent POM)*
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68445642c5ac83279de2daf5be72d972