### PR TITLE
Use import.meta.env.DEV in frontend

### DIFF
--- a/frontend/src/components/providers/AppProviders.tsx
+++ b/frontend/src/components/providers/AppProviders.tsx
@@ -43,8 +43,8 @@ export const AppProviders: React.FC<AppProvidersProps> = ({ children }) => {
         }}
       />
       
-      {process.env.NODE_ENV === 'development' && (
-        <ReactQueryDevtools 
+      {import.meta.env.DEV && (
+        <ReactQueryDevtools
           initialIsOpen={false}
           position="bottom-right"
         />

--- a/frontend/src/utils/analytics.ts
+++ b/frontend/src/utils/analytics.ts
@@ -34,7 +34,7 @@ class Analytics {
   }
 
   private sendEvent(event: AnalyticsEvent) {
-    if (process.env.NODE_ENV === 'development') {
+    if (import.meta.env.DEV) {
       console.log('📊 Analytics:', event);
       return;
     }


### PR DESCRIPTION
## Summary
- replace legacy `process.env.NODE_ENV` checks
- use `import.meta.env.DEV` for Vite

## Testing
- `npm run build` *(fails: Could not resolve "../internals/define-globalThis-property")*
- `npm run lint` *(fails: Invalid option '--ext' - perhaps you meant '-c'?)*

------
https://chatgpt.com/codex/tasks/task_e_6844564526888327b02ad1b53696df99