### PR TITLE
Update README with dependency installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,30 @@ npm run build
 
 Os arquivos de produção ficam em `dist/`.
 
+## Instalação de Dependências para Testes
+
+Antes de executar os testes é necessário baixar todas as dependências do
+backend (Maven) e do frontend (npm). O repositório já fornece o Maven Wrapper,
+portanto não é preciso ter o Maven instalado localmente.
+
+### Backend
+
+```bash
+cd backend/com.tessera
+./mvnw -q dependency:go-offline
+```
+
+### Frontend
+
+```bash
+cd frontend
+npm ci
+```
+
+Para ambientes offline ou de integração contínua, utilize o script
+`scripts/install-dependencies.sh`, que faz o pré-download de todas as
+dependências necessárias.
+
 ## Execução
 
 1. **Backend**

--- a/scripts/install-dependencies.sh
+++ b/scripts/install-dependencies.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+# Instala dependências do backend e frontend para execução de testes
+set -e
+
+# Backend dependencies
+pushd "$(dirname "$0")/../backend/com.tessera" > /dev/null
+./mvnw -q -DskipTests dependency:go-offline
+popd > /dev/null
+
+# Frontend dependencies
+pushd "$(dirname "$0")/../frontend" > /dev/null
+npm ci --prefer-offline --no-audit --progress=false
+popd > /dev/null
+


### PR DESCRIPTION
## Summary
- document installing dependencies for test runs
- add script to pre-download backend and frontend dependencies

## Testing
- `npm test` (frontend)
- `./mvnw test` *(fails: Could not transfer artifact)*

------
https://chatgpt.com/codex/tasks/task_e_68445646930083278153bcd7f427c577