### PR TITLE
Add configurable CORS origins

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ dependências necessárias.
 
 1. **Backend**
 
-   Copie `backend/com.tessera/.env.example` para `.env`, ajuste as variáveis (banco de dados, JWT, etc.) e execute:
+   Copie `backend/com.tessera/.env.example` para `.env`, ajuste as variáveis (banco de dados, JWT, CORS, etc.) e execute:
 
    ```bash
    cd backend/com.tessera
@@ -62,6 +62,7 @@ dependências necessárias.
    ```
 
    O serviço inicia em `http://localhost:8080`.
+   Defina `ALLOWED_ORIGINS` ou a propriedade `app.cors.allowed-origins` para controlar quais origens podem acessar o backend.
 
 2. **Frontend**
 

--- a/backend/com.tessera/.env.example
+++ b/backend/com.tessera/.env.example
@@ -15,6 +15,9 @@ JWT_EXPIRATION=86400000
 # Server
 SERVER_PORT=8080
 
+# CORS
+ALLOWED_ORIGINS=http://localhost:3000
+
 # Email
 MAIL_HOST=smtp.gmail.com
 MAIL_PORT=587

--- a/backend/com.tessera/src/main/java/com/tessera/backend/config/SecurityConfig.java
+++ b/backend/com.tessera/src/main/java/com/tessera/backend/config/SecurityConfig.java
@@ -3,6 +3,7 @@ package com.tessera.backend.config;
 import com.tessera.backend.security.JwtAuthenticationFilter;
 import com.tessera.backend.security.UserDetailsServiceImpl;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.authentication.AuthenticationManager;
@@ -19,6 +20,7 @@ import org.springframework.security.web.authentication.UsernamePasswordAuthentic
 import org.springframework.web.cors.CorsConfiguration;
 import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
 import org.springframework.web.filter.CorsFilter;
+import java.util.List;
 
 @Configuration
 @EnableWebSecurity
@@ -30,6 +32,9 @@ public class SecurityConfig {
 
     @Autowired
     private JwtAuthenticationFilter jwtAuthenticationFilter;
+
+    @Value("${app.cors.allowed-origins:*}")
+    private List<String> allowedOrigins;
 
     @Bean
     public PasswordEncoder passwordEncoder() {
@@ -82,9 +87,7 @@ public class SecurityConfig {
         UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
         CorsConfiguration config = new CorsConfiguration();
         config.setAllowCredentials(true);
-        // config.addAllowedOrigin("http://localhost:3000"); // Se ainda usar
-        config.addAllowedOrigin("http://localhost:3000"); // Frontend URL Vite
-        config.addAllowedOriginPattern("*"); // Para desenvolvimento, pode ser mais permissivo, mas restrinja em produção
+        config.setAllowedOriginPatterns(allowedOrigins);
         config.addAllowedHeader("*");
         config.addAllowedMethod("*");
         source.registerCorsConfiguration("/**", config);
@@ -96,9 +99,7 @@ public class SecurityConfig {
         UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
         CorsConfiguration config = new CorsConfiguration();
         config.setAllowCredentials(true);
-        // config.addAllowedOrigin("http://localhost:3000");
-        config.addAllowedOrigin("http://localhost:3000");
-        config.addAllowedOriginPattern("*"); // Adicionado para flexibilidade em dev
+        config.setAllowedOriginPatterns(allowedOrigins);
         config.addAllowedHeader("*");
         config.addAllowedMethod("*");
         source.registerCorsConfiguration("/**", config);

--- a/backend/com.tessera/src/main/resources/application.properties
+++ b/backend/com.tessera/src/main/resources/application.properties
@@ -20,6 +20,9 @@ app.jwt.expiration=${JWT_EXPIRATION:86400000}
 # Server Configuration
 server.port=${SERVER_PORT:8080}
 
+# CORS Configuration
+app.cors.allowed-origins=${ALLOWED_ORIGINS:*}
+
 # Email Configuration
 spring.mail.host=${MAIL_HOST:smtp.gmail.com}
 spring.mail.port=${MAIL_PORT:587}

--- a/backend/com.tessera/src/test/java/com/tessera/backend/config/SecurityConfigTest.java
+++ b/backend/com.tessera/src/test/java/com/tessera/backend/config/SecurityConfigTest.java
@@ -1,0 +1,34 @@
+package com.tessera.backend.config;
+
+import com.tessera.backend.security.JwtAuthenticationFilter;
+import com.tessera.backend.security.UserDetailsServiceImpl;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.web.cors.CorsConfiguration;
+import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@SpringBootTest(classes = SecurityConfig.class)
+@TestPropertySource(properties = "app.cors.allowed-origins=http://example.com")
+class SecurityConfigTest {
+
+    @MockBean
+    private UserDetailsServiceImpl userDetailsService;
+
+    @MockBean
+    private JwtAuthenticationFilter jwtAuthenticationFilter;
+
+    @Autowired
+    private UrlBasedCorsConfigurationSource corsConfigurationSource;
+
+    @Test
+    void corsConfigurationIncludesConfiguredOrigins() {
+        CorsConfiguration config = corsConfigurationSource.getCorsConfiguration("/**");
+        assertNotNull(config);
+        assertTrue(config.getAllowedOriginPatterns().contains("http://example.com"));
+    }
+}


### PR DESCRIPTION
## Summary
- make allowed CORS origins configurable in `SecurityConfig`
- expose `app.cors.allowed-origins` property
- add `ALLOWED_ORIGINS` variable to `.env.example`
- document configuration of allowed origins in README
- test CORS configuration via new `SecurityConfigTest`

## Testing
- `./mvnw -q test` *(fails: Non-resolvable parent POM due to network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_6844b74593e88327b18f96d4d36eba87