### PR TITLE
Add validation for DocumentDTO

### DIFF
--- a/backend/com.tessera/src/main/java/com/tessera/backend/dto/DocumentDTO.java
+++ b/backend/com.tessera/src/main/java/com/tessera/backend/dto/DocumentDTO.java
@@ -5,13 +5,17 @@ import com.tessera.backend.entity.DocumentStatus;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
+import jakarta.validation.constraints.NotBlank;
 
 @Data
 @NoArgsConstructor
 @AllArgsConstructor
 public class DocumentDTO {
     private Long id;
+    @NotBlank(message = "Título é obrigatório")
     private String title;
+
+    @NotBlank(message = "Descrição é obrigatória")
     private String description;
     private DocumentStatus status;
     private String studentName;

--- a/backend/com.tessera/src/test/java/com/tessera/backend/controller/DocumentControllerValidationTest.java
+++ b/backend/com.tessera/src/test/java/com/tessera/backend/controller/DocumentControllerValidationTest.java
@@ -1,0 +1,73 @@
+package com.tessera.backend.controller;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.tessera.backend.dto.DocumentDTO;
+import com.tessera.backend.entity.User;
+import com.tessera.backend.repository.UserRepository;
+import com.tessera.backend.service.DocumentService;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.util.Optional;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(controllers = DocumentController.class)
+@AutoConfigureMockMvc(addFilters = false)
+class DocumentControllerValidationTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @MockBean
+    private DocumentService documentService;
+
+    @MockBean
+    private UserRepository userRepository;
+
+    @Test
+    void createDocumentWithBlankTitleReturnsBadRequest() throws Exception {
+        DocumentDTO dto = new DocumentDTO();
+        dto.setTitle(" ");
+        dto.setDescription("desc");
+
+        User user = new User();
+        user.setEmail("user@test.com");
+        when(userRepository.findByEmail(any())).thenReturn(Optional.of(user));
+
+        mockMvc.perform(post("/documents")
+                        .with(SecurityMockMvcRequestPostProcessors.user("user@test.com"))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(dto)))
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    void createDocumentWithBlankDescriptionReturnsBadRequest() throws Exception {
+        DocumentDTO dto = new DocumentDTO();
+        dto.setTitle("Title");
+        dto.setDescription("\n\t");
+
+        User user = new User();
+        user.setEmail("user@test.com");
+        when(userRepository.findByEmail(any())).thenReturn(Optional.of(user));
+
+        mockMvc.perform(post("/documents")
+                        .with(SecurityMockMvcRequestPostProcessors.user("user@test.com"))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(dto)))
+                .andExpect(status().isBadRequest());
+    }
+}

--- a/backend/com.tessera/src/test/java/com/tessera/backend/dto/DocumentDTOValidationTest.java
+++ b/backend/com.tessera/src/test/java/com/tessera/backend/dto/DocumentDTOValidationTest.java
@@ -1,0 +1,46 @@
+package com.tessera.backend.dto;
+
+import jakarta.validation.ConstraintViolation;
+import jakarta.validation.Validation;
+import jakarta.validation.Validator;
+import jakarta.validation.ValidatorFactory;
+
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class DocumentDTOValidationTest {
+
+    private static Validator validator;
+
+    @BeforeAll
+    static void setupValidator() {
+        ValidatorFactory factory = Validation.buildDefaultValidatorFactory();
+        validator = factory.getValidator();
+    }
+
+    @Test
+    void blankTitleFailsValidation() {
+        DocumentDTO dto = new DocumentDTO();
+        dto.setTitle(" ");
+        dto.setDescription("desc");
+
+        Set<ConstraintViolation<DocumentDTO>> violations = validator.validate(dto);
+        assertFalse(violations.isEmpty());
+        assertTrue(violations.stream().anyMatch(v -> v.getPropertyPath().toString().equals("title")));
+    }
+
+    @Test
+    void blankDescriptionFailsValidation() {
+        DocumentDTO dto = new DocumentDTO();
+        dto.setTitle("Title");
+        dto.setDescription("\t");
+
+        Set<ConstraintViolation<DocumentDTO>> violations = validator.validate(dto);
+        assertFalse(violations.isEmpty());
+        assertTrue(violations.stream().anyMatch(v -> v.getPropertyPath().toString().equals("description")));
+    }
+}


### PR DESCRIPTION
## Summary
- enforce `@NotBlank` on DocumentDTO title and description
- validate DocumentDTO in unit tests
- add controller test verifying invalid payloads return 400

## Testing
- `./mvnw -q test` *(fails: Could not resolve dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_6844b7497ed48327b1f85e590ff96411