### PR TITLE
Add idle cleanup for editing sessions

### DIFF
--- a/backend/com.tessera/src/main/java/com/tessera/backend/Application.java
+++ b/backend/com.tessera/src/main/java/com/tessera/backend/Application.java
@@ -3,9 +3,11 @@ package com.tessera.backend;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.scheduling.annotation.EnableAsync;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
 @SpringBootApplication
 @EnableAsync
+@EnableScheduling
 public class Application {
 
 	public static void main(String[] args) {

--- a/backend/com.tessera/src/main/java/com/tessera/backend/service/EditingSessionService.java
+++ b/backend/com.tessera/src/main/java/com/tessera/backend/service/EditingSessionService.java
@@ -3,8 +3,11 @@ package com.tessera.backend.service;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Map;
-import java.util.stream.Collectors;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.stream.Collectors;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.scheduling.annotation.Scheduled;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.messaging.simp.SimpMessagingTemplate;
@@ -16,19 +19,45 @@ import com.tessera.backend.entity.User;
 @Service
 public class EditingSessionService {
 
-    private final Map<Long, Map<Long, String>> activeEditors = new ConcurrentHashMap<>();
+    private static class EditorInfo {
+        private final String name;
+        private volatile long lastActive;
+
+        EditorInfo(String name) {
+            this.name = name;
+            this.lastActive = System.currentTimeMillis();
+        }
+
+        void touch() {
+            lastActive = System.currentTimeMillis();
+        }
+
+        void setLastActive(long lastActive) {
+            this.lastActive = lastActive;
+        }
+    }
+
+    private final Map<Long, Map<Long, EditorInfo>> activeEditors = new ConcurrentHashMap<>();
+
+    @Value("${tessera.editing.timeout-ms:300000}")
+    private long timeoutMs;
 
     @Autowired
     private SimpMessagingTemplate messagingTemplate;
 
     public void joinSession(Long documentId, User user) {
-        activeEditors.computeIfAbsent(documentId, k -> new ConcurrentHashMap<>())
-                     .put(user.getId(), user.getName());
+        activeEditors
+            .computeIfAbsent(documentId, k -> new ConcurrentHashMap<>())
+            .compute(user.getId(), (k, v) -> {
+                if (v == null) return new EditorInfo(user.getName());
+                v.touch();
+                return v;
+            });
         broadcast(documentId);
     }
 
     public void leaveSession(Long documentId, User user) {
-        Map<Long, String> map = activeEditors.get(documentId);
+        Map<Long, EditorInfo> map = activeEditors.get(documentId);
         if (map != null) {
             map.remove(user.getId());
             if (map.isEmpty()) {
@@ -39,15 +68,15 @@ public class EditingSessionService {
     }
 
     public boolean hasOtherEditors(Long documentId, Long userId) {
-        Map<Long, String> map = activeEditors.get(documentId);
+        Map<Long, EditorInfo> map = activeEditors.get(documentId);
         if (map == null) return false;
         return map.size() > 1 || (map.size() == 1 && !map.containsKey(userId));
     }
 
     public Collection<EditingSessionDTO> getEditors(Long documentId) {
-        Map<Long, String> map = activeEditors.getOrDefault(documentId, Collections.emptyMap());
+        Map<Long, EditorInfo> map = activeEditors.getOrDefault(documentId, Collections.emptyMap());
         return map.entrySet().stream()
-                   .map(e -> new EditingSessionDTO(documentId, e.getKey(), e.getValue()))
+                   .map(e -> new EditingSessionDTO(documentId, e.getKey(), e.getValue().name))
                    .collect(Collectors.toList());
     }
 
@@ -55,5 +84,30 @@ public class EditingSessionService {
         Collection<EditingSessionDTO> editors = getEditors(documentId);
         String destination = "/topic/documents/" + documentId + "/editors";
         messagingTemplate.convertAndSend(destination, editors);
+    }
+
+    Map<Long, Map<Long, EditorInfo>> getActiveEditors() {
+        return activeEditors;
+    }
+
+    long getTimeoutMs() {
+        return timeoutMs;
+    }
+
+    @Scheduled(fixedRateString = "${tessera.editing.cleanup-interval-ms:60000}")
+    public void cleanupIdleEditors() {
+        long now = System.currentTimeMillis();
+        for (Map.Entry<Long, Map<Long, EditorInfo>> docEntry : activeEditors.entrySet()) {
+            Long docId = docEntry.getKey();
+            Map<Long, EditorInfo> map = docEntry.getValue();
+            int before = map.size();
+            map.entrySet().removeIf(e -> now - e.getValue().lastActive > timeoutMs);
+            if (map.isEmpty()) {
+                activeEditors.remove(docId);
+            }
+            if (before != map.size()) {
+                broadcast(docId);
+            }
+        }
     }
 }

--- a/backend/com.tessera/src/test/java/com/tessera/backend/service/EditingSessionServiceTest.java
+++ b/backend/com.tessera/src/test/java/com/tessera/backend/service/EditingSessionServiceTest.java
@@ -1,0 +1,68 @@
+package com.tessera.backend.service;
+
+import com.tessera.backend.entity.User;
+import com.tessera.backend.dto.EditingSessionDTO;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.messaging.simp.SimpMessagingTemplate;
+
+import java.util.Collection;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+class EditingSessionServiceTest {
+
+    @InjectMocks
+    private EditingSessionService service;
+
+    @Mock
+    private SimpMessagingTemplate messagingTemplate;
+
+    private User user;
+
+    @BeforeEach
+    void setup() {
+        user = new User();
+        user.setId(1L);
+        user.setName("Tester");
+    }
+
+    @Test
+    void testJoinAddsEditor() {
+        service.joinSession(10L, user);
+
+        Collection<EditingSessionDTO> editors = service.getEditors(10L);
+        assertEquals(1, editors.size());
+        assertEquals(user.getId(), editors.iterator().next().getUserId());
+        verify(messagingTemplate).convertAndSend(eq("/topic/documents/10/editors"), any());
+    }
+
+    @Test
+    void testCleanupRemovesIdleEditor() {
+        service.joinSession(5L, user);
+        // simulate idle
+        service.getActiveEditors().get(5L).get(1L).setLastActive(System.currentTimeMillis() - service.getTimeoutMs() - 1000);
+
+        service.cleanupIdleEditors();
+
+        assertTrue(service.getEditors(5L).isEmpty());
+        verify(messagingTemplate).convertAndSend(eq("/topic/documents/5/editors"), any());
+    }
+
+    @Test
+    void testLeaveRemovesEditor() {
+        service.joinSession(7L, user);
+        service.leaveSession(7L, user);
+
+        assertTrue(service.getEditors(7L).isEmpty());
+        verify(messagingTemplate).convertAndSend(eq("/topic/documents/7/editors"), any());
+    }
+}


### PR DESCRIPTION
## Summary
- track timestamp for each editor
- schedule cleanup of idle editors
- enable scheduling in application
- add tests for editing sessions joining, timeout removal and leaving

## Testing
- `./mvnw -q dependency:go-offline` *(fails: Non-resolvable parent POM)*
- `./mvnw -q test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_6844b74a1d9883279009772741d4448a