### PR TITLE
Add advisorId support to document creation

### DIFF
--- a/backend/com.tessera/src/main/java/com/tessera/backend/controller/DocumentController.java
+++ b/backend/com.tessera/src/main/java/com/tessera/backend/controller/DocumentController.java
@@ -52,7 +52,7 @@ public class DocumentController {
         @ApiResponse(responseCode = "404", description = "Estudante ou orientador não encontrado")
     })
     public ResponseEntity<DocumentDTO> createDocument(
-            @Parameter(description = "Dados do documento a ser criado")
+            @Parameter(description = "Dados do documento a ser criado (inclui advisorId opcional)")
             @Valid @RequestBody DocumentDTO documentDTO,
             Authentication authentication) {
         User currentUser = getCurrentUser(authentication);

--- a/backend/com.tessera/src/main/java/com/tessera/backend/dto/DocumentDTO.java
+++ b/backend/com.tessera/src/main/java/com/tessera/backend/dto/DocumentDTO.java
@@ -2,6 +2,7 @@ package com.tessera.backend.dto;
 
 import java.time.LocalDateTime;
 import com.tessera.backend.entity.DocumentStatus;
+import jakarta.validation.constraints.Positive;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
@@ -14,6 +15,8 @@ public class DocumentDTO {
     private String title;
     private String description;
     private DocumentStatus status;
+    @Positive(message = "ID do orientador deve ser positivo")
+    private Long advisorId;
     private String studentName;
     private String advisorName;
     private LocalDateTime createdAt;

--- a/backend/com.tessera/src/main/java/com/tessera/backend/service/DocumentService.java
+++ b/backend/com.tessera/src/main/java/com/tessera/backend/service/DocumentService.java
@@ -64,7 +64,14 @@ public class DocumentService {
         final User student = currentUser;
         User advisor = null;
 
-
+        if (documentDTO.getAdvisorId() != null) {
+            advisor = userRepository.findById(documentDTO.getAdvisorId())
+                    .orElseThrow(() -> new ResourceNotFoundException(
+                            "Orientador não encontrado com ID: " + documentDTO.getAdvisorId()));
+            if (!userHasRole(advisor, "ADVISOR")) {
+                throw new IllegalArgumentException("Usuário informado não possui papel de orientador.");
+            }
+        }
 
         Document document = new Document();
         document.setTitle(documentDTO.getTitle());
@@ -415,6 +422,7 @@ public class DocumentService {
 
         User primaryAdvisor = document.getPrimaryAdvisor();
         if (primaryAdvisor != null) {
+            dto.setAdvisorId(primaryAdvisor.getId());
             dto.setAdvisorName(primaryAdvisor.getName());
         }
         // Se primaryAdvisor for nulo, advisorId e advisorName no DTO permanecerão nulos.

--- a/backend/com.tessera/src/test/java/com/tessera/backend/service/DocumentServiceTest.java
+++ b/backend/com.tessera/src/test/java/com/tessera/backend/service/DocumentServiceTest.java
@@ -75,6 +75,28 @@ class DocumentServiceTest {
     }
 
     @Test
+    void testCreateDocumentWithAdvisorAddsPrimaryAdvisor() {
+        DocumentDTO dto = new DocumentDTO();
+        dto.setTitle("Doc2");
+        dto.setDescription("desc2");
+        dto.setAdvisorId(advisor.getId());
+
+        when(userRepository.findById(advisor.getId())).thenReturn(Optional.of(advisor));
+        when(collaboratorRepository.save(any())).thenAnswer(inv -> inv.getArgument(0));
+        when(documentRepository.save(any(Document.class))).thenAnswer(inv -> inv.getArgument(0));
+
+        ArgumentCaptor<Document> captor = ArgumentCaptor.forClass(Document.class);
+
+        service.createDocument(dto, student);
+
+        verify(documentRepository, times(2)).save(captor.capture());
+        Document finalDoc = captor.getAllValues().get(1);
+        assertEquals(2, finalDoc.getCollaborators().size());
+        assertTrue(finalDoc.getCollaborators().stream()
+                .anyMatch(c -> c.getUser() == advisor && c.getRole() == CollaboratorRole.PRIMARY_ADVISOR));
+    }
+
+    @Test
     void testUpdateDocumentChangesTitleDescriptionAndAdvisor() {
         Document document = new Document();
         document.setId(10L);


### PR DESCRIPTION
## Summary
- extend `DocumentDTO` with optional `advisorId`
- map advisorId in `DocumentService`
- load advisor when creating a document
- clarify controller docs
- test creating documents with an advisor

## Testing
- `./mvnw -q test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_6844b74acbc0832793f2f9552a15885c